### PR TITLE
Adds minimal, additive support for running pyMC Repeater on Luckfox hardware (WeHooper4 LoRa HAT), with no UI changes and no behavior changes for existing platforms.

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -96,6 +96,11 @@ sx1262:
 
   use_dio3_tcxo: false
 
+  # TCXO Voltage (if enabled)
+  # 1.6V is the minimum supported by SX1262/SX1268
+  # Default: 1.8V
+  dio3_tcxo_voltage: 1.8
+
   # Waveshare hardware flag
   is_waveshare: false
 

--- a/radio-settings.json
+++ b/radio-settings.json
@@ -93,6 +93,13 @@
       "tx_power": 22,
       "use_dio3_tcxo": true,
       "preamble_length": 17
+    },
+    "luckfox": {
+      "name": "Luckfox (SX1262/E22 wiring)",
+      "platform": "luckfox",
+      "timezone_utc": true,
+      "use_dio3_tcxo": true,
+      "dio3_tcxo_voltage": 1.8
     }
   }
 }

--- a/repeater/LuckfoxGPIO.py
+++ b/repeater/LuckfoxGPIO.py
@@ -1,0 +1,73 @@
+import os
+import time
+import sys
+
+# MOCK RPi.GPIO Metadata
+RPI_INFO = {
+    'P1_REVISION': 3,
+    'RAM': '1024M',
+    'REVISION': 'a02082',  # This code means "Raspberry Pi 3 Model B"
+    'TYPE': 'Pi 3 Model B',
+    'PROCESSOR': 'BCM2837',
+    'MANUFACTURER': 'Sony'
+}
+
+RPI_REVISION = 3  # Deprecated but sometimes checked
+VERSION = '0.7.0' # Fake RPi.GPIO version
+
+BOARD = 10
+BCM = 11
+OUT = "out"
+IN = "in"
+HIGH = 1
+LOW = 0
+PUD_OFF = 0
+PUD_DOWN = 1
+PUD_UP = 2
+# Add missing constants to satisfy RPi.GPIO checks
+I2C = 42
+SPI = 41
+PWM = 40
+SERIAL = 30
+UNKNOWN = -1
+HARD_PWM = 43
+RISING = 31
+FALLING = 32
+BOTH = 33
+
+def setmode(mode): pass
+def setwarnings(flag): pass
+
+def setup(pin, mode, pull_up_down=PUD_OFF, initial=None):
+    path = f"/sys/class/gpio/gpio{pin}"
+    if not os.path.exists(path):
+        try:
+            with open("/sys/class/gpio/export", "w") as f:
+                f.write(str(pin))
+            time.sleep(0.1)
+        except OSError: pass
+
+    try:
+        with open(f"{path}/direction", "w") as f:
+            f.write("out" if mode == OUT else "in")
+    except OSError: pass
+
+    if mode == OUT and initial is not None:
+        output(pin, initial)
+
+def output(pin, value):
+    try:
+        with open(f"/sys/class/gpio/gpio{pin}/value", "w") as f:
+            f.write("1" if value else "0")
+    except: pass
+
+def input(pin):
+    try:
+        with open(f"/sys/class/gpio/gpio{pin}/value", "r") as f:
+            return int(f.read().strip())
+    except: return 0
+
+def cleanup(channel=None): pass
+
+sys.modules['RPi'] = type('RPi', (object,), {'GPIO': sys.modules[__name__]})
+sys.modules['RPi.GPIO'] = sys.modules[__name__]

--- a/repeater/__init__.py
+++ b/repeater/__init__.py
@@ -1,1 +1,18 @@
+import sys
+import types
+
+# Provide an RPi.GPIO shim on platforms without the real library.
+try:
+    import RPi.GPIO  # type: ignore
+except Exception:
+    try:
+        from . import LuckfoxGPIO as _gpio  # type: ignore
+        rpi_mod = types.ModuleType("RPi")
+        rpi_mod.GPIO = _gpio
+        sys.modules["RPi"] = rpi_mod
+        sys.modules["RPi.GPIO"] = _gpio
+    except Exception:
+        # If loading the shim fails, let downstream imports raise naturally.
+        pass
+
 __version__ = "1.0.5-beta-1"

--- a/repeater/config.py
+++ b/repeater/config.py
@@ -224,6 +224,7 @@ def get_radio_for_board(board_config: dict):
             "txled_pin": spi_config.get("txled_pin", -1),
             "rxled_pin": spi_config.get("rxled_pin", -1),
             "use_dio3_tcxo": spi_config.get("use_dio3_tcxo", False),
+            "dio3_tcxo_voltage": spi_config.get("dio3_tcxo_voltage", 1.4),
             "is_waveshare": spi_config.get("is_waveshare", False),
             "frequency": int(radio_config["frequency"]),
             "tx_power": radio_config["tx_power"],

--- a/repeater/data_acquisition/letsmesh_handler.py
+++ b/repeater/data_acquisition/letsmesh_handler.py
@@ -4,7 +4,13 @@ import binascii
 import base64
 import paho.mqtt.client as mqtt
 
-from datetime import datetime, timedelta, UTC
+# Python 3.11 introduced datetime.UTC; provide a fallback for 3.8–3.10
+try:  # pragma: no cover - tiny compatibility shim
+    from datetime import datetime, timedelta, UTC
+except ImportError:  # Python < 3.11
+    from datetime import datetime, timedelta, timezone
+    UTC = timezone.utc
+
 from nacl.signing import SigningKey
 from typing import Callable, Optional
 from .. import __version__


### PR DESCRIPTION
Changes (8 files)
- NEW: repeater/LuckfoxGPIO.py — RPi.GPIO-compatible shim.
- repeater/__init__.py — map RPi.GPIO to LuckfoxGPIO only if the real lib is missing (no prints).
- repeater/config.py — support sx1262.dio3_tcxo_voltage.
- config.yaml.example — documents dio3_tcxo_voltage.
- repeater/data_acquisition/letsmesh_handler.py — Python 3.10-safe UTC fallback.
- repeater/data_acquisition/hardware_stats.py — Linux /proc fallback when psutil is unavailable.
- radio-settings.json — adds “luckfox” hardware preset (platform, timezone_utc, use_dio3_tcxo, dio3_tcxo_voltage).
- setup-radio-config.sh — writes those preset fields into config when selected.

Non-goals
- No frontend/dashboard changes.
- No protocol/engine behavior changes on non-Luckfox platforms.

Compatibility
- Backwards-compatible: RPi.GPIO shim activates only when the real library is absent.
- psutil fallback is used only if psutil is missing.
- New config keys are optional.

Testing
- On-device (ADB): service starts, /api/stats OK; GPIO shim available when RPi.GPIO is absent.
- Onboarding: selecting “Luckfox” applies timezone_utc/use_dio3_tcxo/dio3_tcxo_voltage.