### PR TITLE
identity_file => identity_key (as it is referenced in the code)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,7 +12,7 @@ repeater:
 
   # Path to identity file (public/private key)
   # If not specified, a new identity will be generated
-  identity_file: null
+  identity_key: null
 
   # Duplicate packet cache TTL in seconds
   cache_ttl: 60


### PR DESCRIPTION
I believe there might be a typo in the example config.yaml: identity_file => identity_key (as it is referenced in the code)