### PR TITLE
feat(config): Add use_dio2_rf configuration option

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -141,6 +141,10 @@ sx1262:
 
   use_dio3_tcxo: false
 
+  # Enable DIO2 as RF switch control
+  # Required for some modules that use DIO2 for TX/RX switching
+  use_dio2_rf: false
+
   # Waveshare hardware flag
   is_waveshare: false
 

--- a/repeater/config.py
+++ b/repeater/config.py
@@ -224,6 +224,7 @@ def get_radio_for_board(board_config: dict):
             "txled_pin": spi_config.get("txled_pin", -1),
             "rxled_pin": spi_config.get("rxled_pin", -1),
             "use_dio3_tcxo": spi_config.get("use_dio3_tcxo", False),
+            "use_dio2_rf": spi_config.get("use_dio2_rf", False),
             "is_waveshare": spi_config.get("is_waveshare", False),
             "frequency": int(radio_config["frequency"]),
             "tx_power": radio_config["tx_power"],


### PR DESCRIPTION
## Summary
Add support for DIO2 RF switch control in `config.yaml`.

Some SX1262 modules require DIO2 for TX/RX switching instead of separate TXEN/RXEN pins.

## Changes
- Add `use_dio2_rf` to `config.py` combined_config
- Document option in `config.yaml.example`

## Usage
In `config.yaml`:
```yaml
sx1262:
  # ... other settings ...
  use_dio2_rf: true  # Enable DIO2 as RF switch control
```

## Dependencies
- Requires pyMC_core PR: https://github.com/rightup/pyMC_core/pull/26

Co-Authored-By: Warp <agent@warp.dev>