### PR TITLE
Reset function for manage.sh

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -344,8 +344,6 @@ EOF
         echo "Please check the error messages above and try again."
         read -p "Press Enter to continue..." || true
     fi
-    systemctl daemon-reload
-    systemctl start "$SERVICE_NAME"
     
     # Show final results
     sleep 2


### PR DESCRIPTION
When testing repeaters sometimes it's convenient to reset to the default config. 

Modified _manage.sh_, adding _reset_repeater_ which follows general them of install and upgrade, but just copies the example yaml to config.yaml in the install directory. 