### PR TITLE
Add timestamp filtering to bulk_packets endpoint

### DIFF
--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -844,7 +844,7 @@ class APIEndpoints:
     @cherrypy.expose
     @cherrypy.tools.gzip(compress_level=6)
     @cherrypy.tools.json_out()
-    def bulk_packets(self, limit=1000, offset=0):
+    def bulk_packets(self, limit=1000, offset=0, start_timestamp=None, end_timestamp=None):
         """
         Optimized bulk packet retrieval with gzip compression and DB-level pagination.
         """
@@ -859,8 +859,8 @@ class APIEndpoints:
             packets = storage.get_filtered_packets(
                 packet_type=None,
                 route=None,
-                start_timestamp=None,
-                end_timestamp=None,
+                start_timestamp=float(start_timestamp) if start_timestamp else None,
+                end_timestamp=float(end_timestamp) if end_timestamp else None,
                 limit=limit,
                 offset=offset
             )


### PR DESCRIPTION
Add start_timestamp and end_timestamp parameters to the bulk_packets API endpoint to allow time-range filtering for bulk packet retrieval.

Co-Authored-By: Warp <agent@warp.dev>