### PR TITLE
Enable gzip compression for bulk_packets endpoint

### DIFF
--- a/repeater/web/http_server.py
+++ b/repeater/web/http_server.py
@@ -299,6 +299,12 @@ class HTTPStatsServer:
                 "/api": {
                     "tools.require_auth.on": True,
                 },
+                # Enable gzip for bulk packet downloads
+                "/api/bulk_packets": {
+                    "tools.gzip.on": True,
+                    "tools.gzip.mime_types": ["application/json"],
+                    "tools.gzip.compress_level": 6,
+                },
                 # Public documentation endpoints (no auth required)
                 "/api/openapi": {
                     "tools.require_auth.on": False,


### PR DESCRIPTION
Enables CherryPy's gzip tool for the `/api/bulk_packets` endpoint to reduce payload size for large packet downloads.

## Changes
- Added gzip configuration for `/api/bulk_packets` with compress_level=6

## Benefits
- Reduces network transfer size for bulk packet requests
- Improves performance on slow network connections

Co-Authored-By: Warp <agent@warp.dev>