### PR TITLE
Add CRC error count endpoint with persistent SQLite storage

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -107,6 +107,14 @@ class SQLiteHandler:
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_adverts_timestamp ON adverts(timestamp)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_adverts_pubkey ON adverts(pubkey)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_noise_timestamp ON noise_floor(timestamp)")
+                
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS crc_errors (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp REAL NOT NULL
+                    )
+                """)
+                conn.execute("CREATE INDEX IF NOT EXISTS idx_crc_errors_timestamp ON crc_errors(timestamp)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_transport_keys_name ON transport_keys(name)")
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_transport_keys_parent ON transport_keys(parent_id)")
                 
@@ -478,6 +486,47 @@ class SQLiteHandler:
         except Exception as e:
             logger.error(f"Failed to store noise floor in SQLite: {e}")
 
+    def store_crc_error(self, timestamp: float):
+        try:
+            with sqlite3.connect(self.sqlite_path) as conn:
+                conn.execute(
+                    "INSERT INTO crc_errors (timestamp) VALUES (?)",
+                    (timestamp,)
+                )
+        except Exception as e:
+            logger.error(f"Failed to store CRC error in SQLite: {e}")
+
+    def get_crc_error_count(self, hours: int = 24) -> dict:
+        try:
+            cutoff = time.time() - (hours * 3600)
+
+            with sqlite3.connect(self.sqlite_path) as conn:
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM crc_errors WHERE timestamp > ?",
+                    (cutoff,)
+                ).fetchone()[0]
+
+                oldest = conn.execute(
+                    "SELECT MIN(timestamp) FROM crc_errors WHERE timestamp > ?",
+                    (cutoff,)
+                ).fetchone()[0]
+
+                newest = conn.execute(
+                    "SELECT MAX(timestamp) FROM crc_errors WHERE timestamp > ?",
+                    (cutoff,)
+                ).fetchone()[0]
+
+                return {
+                    "crc_error_count": count,
+                    "hours": hours,
+                    "oldest_event": oldest,
+                    "newest_event": newest
+                }
+
+        except Exception as e:
+            logger.error(f"Failed to get CRC error count: {e}")
+            return {"crc_error_count": 0, "hours": hours, "oldest_event": None, "newest_event": None}
+
     def get_packet_stats(self, hours: int = 24) -> dict:
         try:
             cutoff = time.time() - (hours * 3600)
@@ -841,10 +890,13 @@ class SQLiteHandler:
                 result = conn.execute("DELETE FROM noise_floor WHERE timestamp < ?", (cutoff,))
                 noise_deleted = result.rowcount
                 
+                result = conn.execute("DELETE FROM crc_errors WHERE timestamp < ?", (cutoff,))
+                crc_deleted = result.rowcount
+                
                 conn.commit()
                 
-                if packets_deleted > 0 or adverts_deleted > 0 or noise_deleted > 0:
-                    logger.info(f"Cleaned up {packets_deleted} old packets, {adverts_deleted} old adverts, {noise_deleted} old noise measurements")
+                if packets_deleted > 0 or adverts_deleted > 0 or noise_deleted > 0 or crc_deleted > 0:
+                    logger.info(f"Cleaned up {packets_deleted} old packets, {adverts_deleted} old adverts, {noise_deleted} old noise measurements, {crc_deleted} old CRC errors")
                     
         except Exception as e:
             logger.error(f"Failed to cleanup old data: {e}")

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -203,6 +203,12 @@ class StorageCollector:
         self.sqlite_handler.store_noise_floor(noise_record)
         self.mqtt_handler.publish(noise_record, "noise_floor")
 
+    def record_crc_error(self, timestamp: float = None):
+        self.sqlite_handler.store_crc_error(timestamp or time.time())
+
+    def get_crc_error_count(self, hours: int = 24) -> dict:
+        return self.sqlite_handler.get_crc_error_count(hours)
+
     def get_packet_stats(self, hours: int = 24) -> dict:
         return self.sqlite_handler.get_packet_stats(hours)
 

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -6,7 +6,7 @@ import sys
 from repeater.config import get_radio_for_board, load_config
 from repeater.config_manager import ConfigManager
 from repeater.engine import RepeaterHandler
-from repeater.web.http_server import HTTPStatsServer, _log_buffer
+from repeater.web.http_server import HTTPStatsServer, _log_buffer, _crc_tracker
 from repeater.handler_helpers import TraceHelper, DiscoveryHelper, AdvertHelper, LoginHelper, TextHelper, PathHelper, ProtocolRequestHelper
 from repeater.packet_router import PacketRouter
 from repeater.identity_manager import IdentityManager
@@ -47,6 +47,8 @@ class RepeaterDaemon:
         root_logger = logging.getLogger()
         _log_buffer.setLevel(getattr(logging, log_level))
         root_logger.addHandler(_log_buffer)
+        _crc_tracker.setLevel(logging.WARNING)
+        root_logger.addHandler(_crc_tracker)
 
     async def initialize(self):
 

--- a/repeater/web/__init__.py
+++ b/repeater/web/__init__.py
@@ -1,4 +1,4 @@
-from .http_server import HTTPStatsServer, StatsApp, LogBuffer, _log_buffer
+from .http_server import HTTPStatsServer, StatsApp, LogBuffer, _log_buffer, CRCErrorTracker, _crc_tracker
 from .api_endpoints import APIEndpoints
 from .cad_calibration_engine import CADCalibrationEngine
 
@@ -6,7 +6,9 @@ __all__ = [
     'HTTPStatsServer',
     'StatsApp', 
     'LogBuffer',
+    'CRCErrorTracker',
     'APIEndpoints',
     'CADCalibrationEngine',
-    '_log_buffer'
+    '_log_buffer',
+    '_crc_tracker'
 ]

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -62,6 +62,9 @@ logger = logging.getLogger("HTTPServer")
 # GET    /api/noise_floor_stats?hours=24 - Get noise floor statistics
 # GET    /api/noise_floor_chart_data?hours=24 - Get noise floor chart data
 
+# Radio Health
+# GET    /api/crc_count?hours=24 - Get CRC error count for time period
+
 # CAD Calibration
 # POST   /api/cad_calibration_start {"samples": 8, "delay": 100} - Start CAD calibration
 # POST   /api/cad_calibration_stop - Stop CAD calibration
@@ -1385,6 +1388,19 @@ class APIEndpoints:
             })
         except Exception as e:
             logger.error(f"Error fetching noise floor chart data: {e}")
+            return self._error(e)
+
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    def crc_count(self, hours: int = 24):
+        """Get CRC error count for the specified time period."""
+        try:
+            storage = self._get_storage()
+            hours = int(hours)
+            stats = storage.get_crc_error_count(hours=hours)
+            return self._success(stats)
+        except Exception as e:
+            logger.error(f"Error fetching CRC error count: {e}")
             return self._error(e)
 
     @cherrypy.expose

--- a/repeater/web/http_server.py
+++ b/repeater/web/http_server.py
@@ -59,6 +59,30 @@ class LogBuffer(logging.Handler):
 _log_buffer = LogBuffer(max_lines=100)
 
 
+class CRCErrorTracker(logging.Handler):
+    """Logging handler that detects CRC errors from SX1262_wrapper and persists them to SQLite."""
+
+    def __init__(self):
+        super().__init__()
+        self._storage = None
+
+    def set_storage(self, storage_collector):
+        """Attach storage collector for persistent writes. Called during server init."""
+        self._storage = storage_collector
+
+    def emit(self, record):
+        try:
+            if record.name == "SX1262_wrapper" and "CRC error detected" in record.getMessage():
+                if self._storage:
+                    self._storage.record_crc_error(record.created)
+        except Exception:
+            self.handleError(record)
+
+
+# Global CRC error tracker instance
+_crc_tracker = CRCErrorTracker()
+
+
 class DocEndpoint:
     """Simple wrapper to serve API docs at /doc"""
     
@@ -190,6 +214,14 @@ class HTTPStatsServer:
         self.app = StatsApp(
             stats_getter, node_name, pub_key, send_advert_func, config, event_loop, daemon_instance, config_path
         )
+        
+        # Connect CRC error tracker to storage for persistent writes
+        try:
+            if daemon_instance and hasattr(daemon_instance, 'repeater_handler') and daemon_instance.repeater_handler:
+                _crc_tracker.set_storage(daemon_instance.repeater_handler.storage)
+                logger.info("CRC error tracker connected to storage")
+        except Exception as e:
+            logger.warning(f"Could not connect CRC error tracker to storage: {e}")
         
         # Create auth endpoints (APIEndpoints has the config_manager)
         self.auth_app = AuthEndpoints(self.config, self.jwt_handler, self.token_manager, self.app.api.config_manager)


### PR DESCRIPTION
## Summary
Adds a new `GET /api/crc_count?hours=24` endpoint that tracks and counts CRC errors detected by the SX1262 radio, with persistent SQLite storage.

## Problem
CRC errors (`[RX] CRC error detected - discarding packet`) are logged by the radio driver but not tracked or queryable via the API. This makes it difficult to monitor radio health over time.

## Changes
- **`sqlite_handler.py`** — New `crc_errors` table with timestamp index, `store_crc_error()` and `get_crc_error_count(hours)` methods, cleanup in `cleanup_old_data()`
- **`storage_collector.py`** — `record_crc_error()` and `get_crc_error_count()` pass-throughs (same pattern as `noise_floor`)
- **`http_server.py`** — `CRCErrorTracker` logging handler that intercepts CRC error log messages from `SX1262_wrapper` and persists them to SQLite
- **`main.py`** — Register `_crc_tracker` on root logger alongside `_log_buffer`
- **`api_endpoints.py`** — New `GET /api/crc_count?hours=24` endpoint
- **`web/__init__.py`** — Export new symbols

## Design
- No pymc_core changes needed — intercepts existing log output via a `logging.Handler`
- Follows the exact same pattern as the existing `noise_floor` feature (table, handler methods, storage pass-through, API endpoint)
- Data automatically cleaned up by existing `cleanup_old_data()` retention policy
- Uses the standard `?hours=24` time period parameter consistent with all other endpoints

## Response Format
```json
{
  "success": true,
  "data": {
    "crc_error_count": 42,
    "hours": 24,
    "oldest_event": 1707350239.044,
    "newest_event": 1707436639.044
  }
}
```

Co-Authored-By: Warp <agent@warp.dev>