### PR TITLE
Update radio settings for PiMesh V1/2

### DIFF
--- a/radio-settings.json
+++ b/radio-settings.json
@@ -55,7 +55,7 @@
       "reset_pin": 18,
       "busy_pin": 5,
       "irq_pin": 6,
-      "txen_pin": 26,
+      "txen_pin": -1,
       "rxen_pin": -1,
       "txled_pin": -1,
       "rxled_pin": -1,

--- a/radio-settings.json
+++ b/radio-settings.json
@@ -59,6 +59,7 @@
       "rxen_pin": -1,
       "txled_pin": -1,
       "rxled_pin": -1,
+      "en_pin": 26,
       "tx_power": 22,
       "use_dio3_tcxo": true,
       "use_dio2_rf": true,

--- a/radio-settings.json
+++ b/radio-settings.json
@@ -31,24 +31,8 @@
       "tx_power": 22,
       "preamble_length": 17
     },
-    "pimesh-1w-usa": {
-      "name": "PiMesh-1W (USA)",
-      "bus_id": 0,
-      "cs_id": 0,
-      "cs_pin": 21,
-      "reset_pin": 18,
-      "busy_pin": 20,
-      "irq_pin": 16,
-      "txen_pin": 13,
-      "rxen_pin": 12,
-      "txled_pin": -1,
-      "rxled_pin": -1,
-      "tx_power": 30,
-      "use_dio3_tcxo": true,
-      "preamble_length": 17
-    },
-    "pimesh-1w-uk": {
-      "name": "PiMesh-1W (UK)",
+    "pimesh-1w-v1": {
+      "name": "PiMesh-1W (V1)",
       "bus_id": 0,
       "cs_id": 0,
       "cs_pin": 21,
@@ -61,6 +45,23 @@
       "rxled_pin": -1,
       "tx_power": 22,
       "use_dio3_tcxo": true,
+      "preamble_length": 17
+    },
+    "pimesh-1w-v2": {
+      "name": "PiMesh-1W (V2)",
+      "bus_id": 0,
+      "cs_id": 0,
+      "cs_pin": 8,
+      "reset_pin": 18,
+      "busy_pin": 5,
+      "irq_pin": 6,
+      "txen_pin": 26,
+      "rxen_pin": -1,
+      "txled_pin": -1,
+      "rxled_pin": -1,
+      "tx_power": 22,
+      "use_dio3_tcxo": true,
+      "use_dio2_rf": true,
       "preamble_length": 17
     },
     "meshadv-mini": {


### PR DESCRIPTION
Added V2 configuration and removed UK/USA configs as they are redundant.