### PR TITLE
Added radio setting for the AIO v2 for uConsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Frequency Labs meshadv
     TX Power: Up to 22dBm
     SPI Bus: SPI0
     GPIO Pins: CS=21, Reset=18, Busy=20, IRQ=16, TXEN=13, RXEN=12, use_dio3_tcxo=True
+
+HT-RA62 module
+    
+    Hardware: Heltec HT-RA62 LoRa module
+    Platform: Raspberry Pi (or compatible single-board computer)
+    Frequency: 868MHz (EU) or 915MHz (US)
+    TX Power: Up to 22dBm
+    SPI Bus: SPI0
+    GPIO Pins: CS=21, Reset=18, Busy=20, IRQ=16, use_dio3_tcxo=True, use_dio2_rf=True
+
 ...
 
 ## Screenshots

--- a/radio-settings.json
+++ b/radio-settings.json
@@ -16,8 +16,8 @@
       "preamble_length": 17,
       "is_waveshare": true
     },
-    "uconsole": {
-      "name": "uConsole LoRa Module",
+    "uconsole_aiov1": {
+      "name": "uConsole LoRa Module aio v1",
       "bus_id": 1,
       "cs_id": 0,
       "cs_pin": -1,
@@ -30,6 +30,23 @@
       "rxled_pin": -1,
       "tx_power": 22,
       "preamble_length": 17
+    },
+     "uconsole_aio_v2": {
+      "name": "uConsole LoRa Module aio v2",
+      "bus_id": 1,
+      "cs_id": 0,
+      "cs_pin": -1,
+      "reset_pin": 25,
+      "busy_pin": 24,
+      "irq_pin": 26,
+      "txen_pin": -1,
+      "rxen_pin": -1,
+      "txled_pin": -1,
+      "rxled_pin": -1,
+      "tx_power": 22,
+      "preamble_length": 17,
+      "use_dio3_tcxo": true,
+      "use_dio2_rf": true
     },
     "pimesh-1w-usa": {
       "name": "PiMesh-1W (USA)",


### PR DESCRIPTION
AIO v2 for the uconsole requires two settings to work correctly

Thanks to this [post](https://forum.clockworkpi.com/t/uconsole-is-very-cool-for-meshcore-exploration/21492) for finding the working settings.