### PR TITLE
Move MQTT configuration location was incorrect

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -114,28 +114,28 @@ duty_cycle:
   # Maximum airtime per minute in milliseconds
   max_airtime_per_minute: 3600
 
+# MQTT publishing configuration (optional)
+mqtt:
+  # Enable/disable MQTT publishing
+  enabled: false
+  
+  # MQTT broker settings
+  broker: "localhost"
+  port: 1883
+  
+  # Authentication (optional)
+  username: null
+  password: null
+  
+  # Base topic for publishing
+  # Messages will be published to: {base_topic}/{node_name}/{packet|advert}
+  base_topic: "meshcore/repeater"
+
 
 # Storage Configuration
 storage:
   # Directory for persistent storage files (SQLite, RRD)
   storage_dir: "/var/lib/pymc_repeater"
-
-  # MQTT publishing configuration (optional)
-  mqtt:
-    # Enable/disable MQTT publishing
-    enabled: false
-    
-    # MQTT broker settings
-    broker: "localhost"
-    port: 1883
-    
-    # Authentication (optional)
-    username: null
-    password: null
-    
-    # Base topic for publishing
-    # Messages will be published to: {base_topic}/{node_name}/{packet|advert}
-    base_topic: "meshcore/repeater"
 
   # Data retention settings
   retention:


### PR DESCRIPTION
The MQTT configuration needs to be at the root of the config not in the storage