### PR TITLE
Feat/add ultra peater boards

### DIFF
--- a/radio-presets.json
+++ b/radio-presets.json
@@ -21,6 +21,14 @@
                     "title": "Australia",
                     "description": "915.800MHz / SF10 / BW250 / CR5",
                     "frequency": "915.800",
+                    "spreading_factor": "10",
+                    "bandwidth": "250",
+                    "coding_rate": "5"
+                },
+                {
+                    "title": "Australia: NSW (Wide)",
+                    "description": "915.800MHz / SF11 / BW250 / CR5",
+                    "frequency": "915.800",
                     "spreading_factor": "11",
                     "bandwidth": "250",
                     "coding_rate": "5"

--- a/radio-presets.json
+++ b/radio-presets.json
@@ -21,7 +21,7 @@
                     "title": "Australia",
                     "description": "915.800MHz / SF10 / BW250 / CR5",
                     "frequency": "915.800",
-                    "spreading_factor": "10",
+                    "spreading_factor": "11",
                     "bandwidth": "250",
                     "coding_rate": "5"
                 },

--- a/radio-settings.json
+++ b/radio-settings.json
@@ -205,6 +205,45 @@
       "dio3_tcxo_voltage": 1.8,
       "preamble_length": 17,
       "is_waveshare": false
+    },
+      "ultrapeater-e22": {
+      "name": "Zindello Industries UltraPeater E22",
+      "bus_id": 0,
+      "cs_id": 0,
+      "cs_pin": 16,
+      "reset_pin": 22,
+      "busy_pin": 11,
+      "irq_pin": 10,
+      "txen_pin": 20,
+      "rxen_pin": 21,
+      "txled_pin": 8,
+      "rxled_pin": 1,
+      "tx_power": 22,
+      "use_dio2_rf": false,
+      "use_dio3_tcxo": true,
+      "preamble_length": 17,
+      "use_gpiod_backend": true,
+      "gpio_chip": 1
+    },
+      "ultrapeater-e22p": {
+      "name": "Zindello Industries UltraPeater E22P",
+      "bus_id": 0,
+      "cs_id": 0,
+      "cs_pin": 16,
+      "reset_pin": 22,
+      "busy_pin": 11,
+      "irq_pin": 10,
+      "txen_pin": 20,
+      "rxen_pin": -1,
+      "en_pin": 21,
+      "txled_pin": 8,
+      "rxled_pin": 1,
+      "tx_power": 22,
+      "use_dio2_rf": false,
+      "use_dio3_tcxo": true,
+      "preamble_length": 17,
+      "use_gpiod_backend": true,
+      "gpio_chip": 1
     }
   }
 }


### PR DESCRIPTION
This PR adds board definitons for the UltraPeater in both the E22 and the E22P variant, it also adds a new preset (so as not to cause any arguments) for the NSW Wide network which runs SF11 not SF10.

Reference:

https://nswmesh.au/docs/meshcore/sydney-meshcore.html (Note Australia base configuration)
https://bxmesh.net/meshcore/start.html