### PR TITLE
fix: early duplicate exit to prevent flood loop processing overhead

### DIFF
--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -150,18 +150,19 @@ class StorageCollector:
         # Broadcast to WebSocket clients for real-time updates
         if self.websocket_available:
             try:
-                self.websocket_broadcast_packet(packet_record)
-                
-                # Broadcast 24-hour packet stats (same as /api/packet_stats?hours=24)
-                packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
-                uptime_seconds = time.time() - self.repeater_handler.start_time if self.repeater_handler else 0
-                
-                self.websocket_broadcast_stats({
-                    "packet_stats": packet_stats_24h,
-                    "system_stats": {
-                        "uptime_seconds": uptime_seconds,
-                    }
-                })
+                from .websocket_handler import _connected_clients
+                if not _connected_clients:
+                    pass  # No clients connected — skip expensive broadcast + stats query
+                else:
+                    self.websocket_broadcast_packet(packet_record)
+                    packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
+                    uptime_seconds = time.time() - self.repeater_handler.start_time if self.repeater_handler else 0
+                    self.websocket_broadcast_stats({
+                        "packet_stats": packet_stats_24h,
+                        "system_stats": {
+                            "uptime_seconds": uptime_seconds,
+                        }
+                    })
             except Exception as e:
                 logger.debug(f"WebSocket broadcast failed: {e}")
 

--- a/repeater/engine.py
+++ b/repeater/engine.py
@@ -121,6 +121,36 @@ class RepeaterHandler(BaseHandler):
             f"rssi={metadata.get('rssi', 'N/A')}, snr={metadata.get('snr', 'N/A')}, mode={mode}"
         )
 
+        # --- Early duplicate check (before expensive processing) ---
+        # Matches C++ MeshCore behavior: hasSeen() is checked BEFORE any
+        # processing.  The packet hash excludes path data (except TRACE),
+        # so flood packets looping with different paths (e.g. the
+        # "35 35 35 35" pattern) are correctly caught here.  Without this
+        # early exit every path-variant duplicate triggers the full storage
+        # pipeline (deepcopy, SQLite INSERT, 19x COUNT(*), MQTT, WS, etc.)
+        if not local_transmission:
+            pkt_hash_early = packet.calculate_packet_hash().hex().upper()
+            if pkt_hash_early in self.seen_packets:
+                self.dropped_count += 1
+                logger.debug(f"Early duplicate drop (hash {pkt_hash_early[:16]})")
+                # Lightweight record for dashboard only — skip storage
+                header_info = PacketHeaderUtils.parse_header(packet.header)
+                self.recent_packets.append({
+                    "timestamp": time.time(),
+                    "type": header_info["payload_type"],
+                    "route": header_info["route_type"],
+                    "length": len(packet.payload or b""),
+                    "rssi": metadata.get("rssi", 0),
+                    "snr": metadata.get("snr", 0.0),
+                    "transmitted": False,
+                    "is_duplicate": True,
+                    "drop_reason": "Duplicate",
+                    "packet_hash": pkt_hash_early[:16],
+                })
+                if len(self.recent_packets) > self.max_recent_packets:
+                    self.recent_packets.pop(0)
+                return
+
         # clone the packet to avoid modifying the original
         processed_packet = copy.deepcopy(packet)
 
@@ -776,6 +806,19 @@ class RepeaterHandler(BaseHandler):
                     await self._record_noise_floor_async()
                     await self._record_crc_errors_async()
                     self.last_noise_measurement = current_time
+
+                # Periodic maintenance: prune seen-packet cache and old DB rows
+                if not hasattr(self, '_last_cleanup_time'):
+                    self._last_cleanup_time = current_time
+                if current_time - self._last_cleanup_time >= 21600:  # every 6 hours
+                    self.cleanup_cache()
+                    if self.storage:
+                        try:
+                            self.storage.cleanup_old_data(days=7)
+                            logger.info("Periodic DB cleanup completed")
+                        except Exception as e:
+                            logger.error(f"Periodic DB cleanup failed: {e}")
+                    self._last_cleanup_time = current_time
 
                 # Check advert sending (every N hours)
                 if self.send_advert_interval_hours > 0 and self.send_advert_func:


### PR DESCRIPTION
## Problem

Pi Zero W2 nodes running pyMC_Repeater slowly max out memory over ~12 hours, correlated with pathological flood routing loops (e.g. the `35 35 35 35` repeating path pattern).

## Root Cause

Flood packets looping through the mesh arrive with **different paths** each iteration. The dispatcher-level dedup hashes raw bytes (including path), so these look like new packets. The engine-level dedup correctly identifies them as duplicates (the payload hash excludes path, matching C++ MeshCore's `calculatePacketHash`), but only **after** the full processing pipeline has already run:

- `copy.deepcopy(packet)`
- SQLite INSERT
- 19× `COUNT(*)` full-table-scan queries (`get_cumulative_counts`)
- RRD update
- MQTT publish
- WebSocket broadcast + `get_packet_stats(hours=24)` query
- LetsMesh publish

In C++ MeshCore, `hasSeen()` is the **first check** — duplicates are immediately freed with zero further processing. pyMC_Repeater was missing this early exit.

## Fix (3 surgical changes)

1. **Early duplicate check in `engine.__call__`** — before `deepcopy` and the storage pipeline. Uses the same payload-based hash (excludes path) that already exists. Duplicates get a lightweight in-memory record for the dashboard and return immediately.

2. **Guard WebSocket stats behind connected-clients check** — `get_packet_stats(hours=24)` was running on every packet even with zero WebSocket clients, because `websocket_available` was just an import check.

3. **Periodic `cleanup_old_data()` + `cleanup_cache()`** — both existed but were never called from production code. Added to the background timer (every 6 hours).

## Impact

During the `35 35 35` loop events, this eliminates the majority of per-packet processing overhead for duplicate flood packets. Each early-exit duplicate now costs ~1 hash lookup + 1 dict append instead of the full pipeline.

Co-Authored-By: Oz <oz-agent@warp.dev>