### PR TITLE
Add RAK7391 + RAK13300 WisBlock radio presets (slots A & B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ HT-RA62 module
     SPI Bus: SPI0
     GPIO Pins: CS=21, Reset=18, Busy=20, IRQ=16, use_dio3_tcxo=True, use_dio2_rf=True
 
+RAK7391 + RAK13300 (SPI, WisBlock slot via GPIO expander)
+
+    Hardware: RAK7391 + RAK13300 (SX1262)
+    Platform: Raspberry Pi CM4/CM5 inside RAK7391
+    Frequency: 868MHz (EU) or 915MHz (US)
+    TX Power: Up to 22 dBm
+    SPI Bus: SPI0
+    SPI Devices: /dev/spidev0.0 (slot A), /dev/spidev0.1 (slot B)
+    GPIO Pins (slot A): CS=0, Reset=4, Busy=5, IRQ=6
+    GPIO Pins (slot B): CS=1, Reset=12, Busy=13, IRQ=14
+
 ...
 
 ## Screenshots

--- a/radio-settings.json
+++ b/radio-settings.json
@@ -244,6 +244,48 @@
       "preamble_length": 17,
       "use_gpiod_backend": true,
       "gpio_chip": 1
+    },
+      "rak13300-slot-A": {
+      "name": "Rak7391 + rak13300 LoRa Module, slot: A",
+      "bus_id": 0,
+      "cs_id": 0,
+      "cs_pin": -1,
+      "reset_pin": 4,
+      "busy_pin": 5,
+      "irq_pin": 6,
+      "txen_pin": -1,
+      "rxen_pin": -1,
+      "txled_pin": -1,
+      "rxled_pin": -1,
+      "tx_power": 22,
+      "preamble_length": 17,
+      "use_dio3_tcxo": true,
+      "dio3_tcxo_voltage": 1.8,
+      "use_dio2_rf": false,
+      "is_waveshare": false,
+      "use_gpiod_backend": true,
+      "gpio_chip": 2
+    },
+      "rak13300-slot-B": {
+      "name": "Rak7391 + rak13300 LoRa Module, slot: B",
+      "bus_id": 0,
+      "cs_id": 1,
+      "cs_pin": -1,
+      "reset_pin": 12,
+      "busy_pin": 13,
+      "irq_pin": 14,
+      "txen_pin": -1,
+      "rxen_pin": -1,
+      "txled_pin": -1,
+      "rxled_pin": -1,
+      "tx_power": 22,
+      "preamble_length": 17,
+      "use_dio3_tcxo": true,
+      "dio3_tcxo_voltage": 1.8,
+      "use_dio2_rf": false,
+      "is_waveshare": false,
+      "use_gpiod_backend": true,
+      "gpio_chip": 2
     }
   }
 }

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -468,7 +468,8 @@ class APIEndpoints:
                 config_yaml['sx1262']['txled_pin'] = hw_config.get('txled_pin', -1)
             if 'rxled_pin' in hw_config:
                 config_yaml['sx1262']['rxled_pin'] = hw_config.get('rxled_pin', -1)
-            
+            if "en_pin" in hw_config:
+                config_yaml["sx1262"]["en_pin"] = hw_config.get("en_pin", -1)          
             # Hardware flags
             if 'use_dio3_tcxo' in hw_config:
                 config_yaml['sx1262']['use_dio3_tcxo'] = hw_config.get('use_dio3_tcxo', False)


### PR DESCRIPTION
<head></head><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; font-weight: 600; color: rgba(228, 228, 228, 0.92); margin-top: 18px; font-family: -apple-system, system-ui, sans-serif; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial;">Changes</h3><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; list-style-type: disc; padding-left: 2em; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, system-ui, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; padding: 0px !important;"><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-filename">radio-settings.json</span></code>: new entries<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">rak13300-slot-A</code><span> </span>and<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">rak13300-slot-B</code>.</li></ul><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; font-weight: 600; color: rgba(228, 228, 228, 0.92); margin-top: 18px; font-family: -apple-system, system-ui, sans-serif; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial;">Hardware mapping</h3><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border: 1px solid color(srgb 0.894118 0.894118 0.894118 / 0.073725); border-radius: 6px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, system-ui, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-row-start: 1; grid-column-start: 1; grid-row-end: auto; grid-column-end: auto; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; scrollbar-width: none;"><div class="ui-scroll-area__content" style="width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">


| Slot | SPI device | bus_id / cs_id | Control lines (IO expander line offsets) |
|------|------------|----------------|------------------------------------------|
| A | `/dev/spidev0.0` | 0 / 0 | Reset=4, Busy=5, IRQ=6 |
| B | `/dev/spidev0.1` | 0 / 1 | Reset=12, Busy=13, IRQ=14 |


</div></div></div><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; list-style-type: disc; padding-left: 2em; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, system-ui, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; padding: 0px !important;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">cs_pin: -1</code><span> </span>(hardware chip select)</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; padding: 0px !important;"><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">use_gpiod_backend: true</code><span> </span>(GPIO via character device; IRQ path uses polling where applicable)</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; padding: 0px !important;"><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">gpio_chip</code>: Linux gpiochip index for the expander — must match<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-prefix">/dev/</span><span class="md-inline-path-filename">gpiochipN</span></code><span> </span>(confirm with<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">gpioinfo</code><span> </span>/ docs)</li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; padding: 0px !important;"><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">use_dio3_tcxo</code><span> </span>/<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); color: rgba(228, 228, 228, 0.92); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">dio3_tcxo_voltage</code>: typical RAK13300 SX1262 + TCXO usage</li></ul><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; font-weight: 600; color: rgba(228, 228, 228, 0.92); margin-top: 18px; font-family: -apple-system, system-ui, sans-serif; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial;">Notes</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; margin: 6px 0px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, system-ui, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial;">Slot B uses a different SPI chip select and different reset/busy/IRQ lines than slot A. Drafts that reused slot A pins for slot B are incorrect for this hardware.</p><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; font-weight: 600; color: rgba(228, 228, 228, 0.92); margin-top: 18px; font-family: -apple-system, system-ui, sans-serif; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial;">Testing</h3><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6 contains-task-list" data-streamdown="unordered-list" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-block: 0px 16px; list-style: none; padding-left: 0px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, system-ui, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(24, 24, 24); text-decoration-color: initial; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important;"><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; display: flex; align-items: baseline; gap: 0.4em; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; flex-shrink: 0;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; color: inherit; font-family: inherit; font-size: 13px; outline: transparent 0px !important; outline-offset: 0px !important;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; width: 12px; height: 12px; color: rgb(25, 28, 34); border: 1px solid color(srgb 0.894118 0.894118 0.894118 / 0.147451); border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); opacity: 0.5;"></span></span>RAK7391 + RAK13300 in slot A</li><li class="py-1 [&amp;&gt;p]:inline task-list-item" data-streamdown="list-item" style="padding-block: 4px; display: flex; align-items: baseline; gap: 0.4em; padding: 0px !important;"><span class="ui-checkbox" data-size="compact" data-variant="neutral" aria-disabled="true" style="display: inline-flex; align-items: center; justify-content: center; position: relative; cursor: default; top: 1px; flex-shrink: 0;"><input disabled="" class="ui-checkbox__input" aria-label="Incomplete task" type="checkbox" style="padding: 0px; margin: 0px; position: absolute; inset: 0px; opacity: 0; cursor: inherit; color: inherit; font-family: inherit; font-size: 13px; outline: transparent 0px !important; outline-offset: 0px !important;"><span class="ui-checkbox__box" data-disabled="true" aria-hidden="true" style="display: inline-flex; align-items: center; justify-content: center; transition-property: color, background-color, border-color, opacity, transform; transition-duration: 150ms; transition-timing-function: ease; width: 12px; height: 12px; color: rgb(25, 28, 34); border: 1px solid color(srgb 0.894118 0.894118 0.894118 / 0.147451); border-radius: 4px; background-color: color(srgb 0.894118 0.894118 0.894118 / 0.036863); opacity: 0.5;"></span></span>RAK7391 + RAK13300 in slot B</li></ul>

**Links:** 
[RAK13300](https://docs.rakwireless.com/product-categories/wisblock/rak13300/datasheet/)
[RAK7391](https://docs.rakwireless.com/product-categories/wisgate/rak7391/connecting-to-wisblock/)