### PR TITLE
Add NULLHOP MeshToad V3 hardware profile and gpio_chip config support

### DIFF
--- a/radio-settings.json
+++ b/radio-settings.json
@@ -78,7 +78,7 @@
       "tx_power": 22,
       "preamble_length": 17
     },
-      "meshadv": {
+    "meshadv": {
       "name": "MeshAdv",
       "bus_id": 0,
       "cs_id": 0,
@@ -93,6 +93,26 @@
       "tx_power": 22,
       "use_dio3_tcxo": true,
       "preamble_length": 17
+    },
+    "meshtoad-v3": {
+      "name": "NULLHOP MeshToad V3 (USB)",
+      "bus_id": 7,
+      "cs_id": 0,
+      "cs_pin": -1,
+      "reset_pin": 2,
+      "busy_pin": 4,
+      "irq_pin": 6,
+      "txen_pin": -1,
+      "rxen_pin": 1,
+      "txled_pin": -1,
+      "rxled_pin": -1,
+      "tx_power": 30,
+      "preamble_length": 17,
+      "is_waveshare": false,
+      "use_dio3_tcxo": true,
+      "use_dio2_rf": true,
+      "gpio_chip": "/dev/gpiochip2",
+      "notes": "CH341 USB-SPI bridge. Requires frank-zago/ch341-i2c-spi-gpio kernel driver. Bus number may vary - check /sys/class/spi_master/ after driver loads."
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the NULLHOP MeshToad V3 as a supported hardware profile and threads
a `gpio_chip` configuration option through `get_radio_for_board()` so
that USB GPIO adapters (CH341 and similar) can specify which `/dev/gpiochipN`
device their GPIO lines live on.

Companion to pymc_core PR: (link once opened)
> **Note:** This PR depends on the pymc_core PR above. The `gpio_chip`
> field in `radio-settings.json` and `config.yaml` has no effect until
> pymc_core accepts the `gpio_chip` parameter in `SX1262Radio`.

## Changes

### `repeater/config.py`
- `get_radio_for_board()`: reads `gpio_chip` from the `sx1262` config
  section and passes it to `SX1262Radio()`. Defaults to
  `/dev/gpiochip0` preserving all existing behavior.

### `radio-settings.json`
- Adds `meshtoad-v3` hardware profile with the correct pin mapping for
  the NULLHOP MeshToad V3:

| Signal   | CH341 GPIO line | Notes                        |
|----------|-----------------|------------------------------|
| RXen     | 1               | Active high in RX mode       |
| Reset    | 2               |                              |
| Busy     | 4               |                              |
| IRQ/DIO1 | 6               |                              |
| CS       | Hardware        | spidev handles CS natively   |
| DIO2     | Internal        | RF switch, controlled by SX1262 |
| DIO3     | Internal        | TCXO power, controlled by SX1262 |

Pin mapping sourced from Meshtastic firmware PR meshtastic/firmware#6339
(vidplace7, wehooper4).

## Hardware Setup Requirements

The MeshToad V3 requires the frank-zago CH341 kernel driver to expose
spidev and gpiochip interfaces:

```bash
git clone https://github.com/frank-zago/ch341-i2c-spi-gpio
cd ch341-i2c-spi-gpio && make && sudo make install
sudo modprobe ch341_core spi_ch341 gpio_ch341 spidev
echo spidev 0 | sudo tee /sys/class/spi_master/spi*/new_device
```

The `gpio_chip` value (`/dev/gpiochip2`) may vary depending on how many
other gpiochip devices are present — users should verify with `gpiodetect`
after the driver loads.

## Backward Compatibility

- `gpio_chip` defaults to `/dev/gpiochip0` in `get_radio_for_board()`,
  so all existing hardware profiles are completely unaffected.
- No changes to the setup wizard or existing profile structure.

## Tested On

- NULLHOP MeshToad V3 (muzi.works)
- Raspberry Pi 4B, Raspberry Pi OS Bookworm 64-bit
- Kernel 6.12.75+rpt-rpi-v8
- pyMC_Repeater running as a live MeshCore repeater

## References

- MeshToad product page: https://muzi.works/products/nullhop-meshtoad-v3
- MeshToad hardware design: https://oshwlab.com/mtnmesh/meshtoad-v1-2
- Pin mapping source: meshtastic/firmware#6339
- CH341 driver: https://github.com/frank-zago/ch341-i2c-spi-gpio