### PR TITLE
perf: guard hot-path debug log f-strings with isEnabledFor(DEBUG)

### DIFF
--- a/repeater/engine.py
+++ b/repeater/engine.py
@@ -168,11 +168,12 @@ class RepeaterHandler(BaseHandler):
         allow_forward = mode == "forward"
         allow_local_tx = mode != "no_tx"
 
-        logger.debug(
-            f"RX packet: header=0x{packet.header:02x}, payload_len={len(packet.payload or b'')}, "
-            f"path_len={len(packet.path) if packet.path else 0}, "
-            f"rssi={metadata.get('rssi', 'N/A')}, snr={metadata.get('snr', 'N/A')}, mode={mode}"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"RX packet: header=0x{packet.header:02x}, payload_len={len(packet.payload or b'')}, "
+                f"path_len={len(packet.path) if packet.path else 0}, "
+                f"rssi={metadata.get('rssi', 'N/A')}, snr={metadata.get('snr', 'N/A')}, mode={mode}"
+            )
 
         # clone the packet to avoid modifying the original
         processed_packet = copy.deepcopy(packet)
@@ -205,7 +206,8 @@ class RepeaterHandler(BaseHandler):
             delay = self._calculate_tx_delay(packet, snr)
             result = (packet, delay)
             forwarded_path_hashes = packet.get_path_hashes_hex()
-            logger.debug(f"Local transmission: calculated delay {delay:.3f}s")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Local transmission: calculated delay {delay:.3f}s")
 
         if result:
             fwd_pkt, delay = result
@@ -305,7 +307,8 @@ class RepeaterHandler(BaseHandler):
                 drop_reason = processed_packet.drop_reason or self._get_drop_reason(
                     processed_packet
                 )
-                logger.debug(f"Packet not forwarded: {drop_reason}")
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"Packet not forwarded: {drop_reason}")
 
         # Extract packet type and route from header
         if not hasattr(packet, "header") or packet.header is None:
@@ -316,9 +319,10 @@ class RepeaterHandler(BaseHandler):
             header_info = PacketHeaderUtils.parse_header(packet.header)
             payload_type = header_info["payload_type"]
             route_type = header_info["route_type"]
-            logger.debug(
-                f"Packet header=0x{packet.header:02x}, type={payload_type}, route={route_type}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Packet header=0x{packet.header:02x}, type={payload_type}, route={route_type}"
+                )
 
         # Check if this is a duplicate
         is_dupe = pkt_hash_full in self.seen_packets and not transmitted
@@ -750,9 +754,10 @@ class RepeaterHandler(BaseHandler):
                     transport_key = base64.b64decode(transport_key_encoded)
                     expected_code = calc_transport_code(transport_key, packet)
                     if transport_code_0 == expected_code:
-                        logger.debug(
-                            f"Transport code validated for key '{key_name}' with policy '{flood_policy}'"
-                        )
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                f"Transport code validated for key '{key_name}' with policy '{flood_policy}'"
+                            )
 
                         # Update last_used timestamp for this key
                         try:
@@ -761,9 +766,10 @@ class RepeaterHandler(BaseHandler):
                                 self.storage.update_transport_key(
                                     key_id=key_id, last_used=time.time()
                                 )
-                                logger.debug(
-                                    f"Updated last_used timestamp for transport key '{key_name}'"
-                                )
+                                if logger.isEnabledFor(logging.DEBUG):
+                                    logger.debug(
+                                        f"Updated last_used timestamp for transport key '{key_name}'"
+                                    )
                         except Exception as e:
                             logger.warning(
                                 f"Failed to update last_used for transport key '{key_name}': {e}"
@@ -780,9 +786,10 @@ class RepeaterHandler(BaseHandler):
                     continue
 
             # No matching transport code found
-            logger.debug(
-                f"Transport code 0x{transport_code_0:04X} denied (checked {len(transport_keys)} keys)"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Transport code 0x{transport_code_0:04X} denied (checked {len(transport_keys)} keys)"
+                )
             return False, "No matching transport code"
 
         except Exception as e:
@@ -954,18 +961,20 @@ class RepeaterHandler(BaseHandler):
             # score 0.0 → multiplier 1.0 (100% of original)
             score_multiplier = max(0.2, 1.0 - score)
             delay_s = delay_s * score_multiplier
-            logger.debug(
-                f"Congestion detected (delay >= 50ms), score={score:.2f}, "
-                f"delay multiplier={score_multiplier:.2f}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Congestion detected (delay >= 50ms), score={score:.2f}, "
+                    f"delay multiplier={score_multiplier:.2f}"
+                )
 
         # Cap at 5 seconds maximum
         delay_s = min(delay_s, 5.0)
 
-        logger.debug(
-            f"Route={'FLOOD' if route_type == ROUTE_TYPE_FLOOD else 'DIRECT'}, "
-            f"len={packet_len}B, airtime={airtime_ms:.1f}ms, delay={delay_s:.3f}s"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Route={'FLOOD' if route_type == ROUTE_TYPE_FLOOD else 'DIRECT'}, "
+                f"len={packet_len}B, airtime={airtime_ms:.1f}ms, delay={delay_s:.3f}s"
+            )
 
         return delay_s
 


### PR DESCRIPTION
## Problem

Python evaluates f-string arguments **before** calling `logger.debug()`. In production at `INFO` level every debug log call still pays the cost of string formatting, attribute lookups, and arithmetic — and then discards the result because the level check inside the logger rejects it.

The most expensive unguarded sites run on **every received packet**:

```python
# __call__ — runs on every RX packet
logger.debug(
    f"RX packet: header=0x{packet.header:02x}, payload_len={len(packet.payload or b'')}, "
    f"path_len={len(packet.path) if packet.path else 0}, "
    f"rssi={metadata.get('rssi', 'N/A')}, snr={metadata.get('snr', 'N/A')}, mode={mode}"
)

# __call__ — runs on every RX packet (after header parse)
logger.debug(
    f"Packet header=0x{packet.header:02x}, type={payload_type}, route={route_type}"
)

# _calculate_tx_delay — runs on every forwarded packet
logger.debug(
    f"Route={'FLOOD' if route_type == ROUTE_TYPE_FLOOD else 'DIRECT'}, "
    f"len={packet_len}B, airtime={airtime_ms:.1f}ms, delay={delay_s:.3f}s"
)
```

## Fix

Wrap each f-string `logger.debug()` call with `if logger.isEnabledFor(logging.DEBUG):`:

```python
if logger.isEnabledFor(logging.DEBUG):
    logger.debug(
        f"RX packet: header=0x{packet.header:02x}, ..."
    )
```

`logger.isEnabledFor()` is a pure in-memory integer comparison — essentially free at runtime. In production at INFO level this eliminates string concatenation, `packet.header` attribute lookups, `len()` calls, `metadata.get()` calls, and format operations on every forwarded packet.

## Guarded Call Sites (8 total)

| Location | Runs on |
|----------|---------|
| `__call__`: RX packet summary | Every received packet |
| `__call__`: Packet header type/route | Every received packet |
| `__call__`: Local TX delay | Every local transmission |
| `__call__`: Packet not forwarded | Every dropped packet |
| `_calculate_tx_delay`: Congestion score | Every congestion-adjusted delay |
| `_calculate_tx_delay`: Route/airtime/delay | Every forwarded packet |
| `_check_transport_codes`: Code validated | Every TRANSPORT_FLOOD/DIRECT packet |
| `_check_transport_codes`: Code denied | Every rejected transport packet |

## No Logic Changes

This is a pure performance guard. All eight call sites produce identical output when debug logging is enabled. Nothing is removed or changed — only the evaluation is deferred behind a level check.

## Test Plan

- [ ] Run with `logging.DEBUG` enabled: verify all 8 debug messages still appear in logs
- [ ] Run with `logging.INFO` (production): verify no debug messages appear and CPU profile shows reduced string allocation in `__call__` hot path
- [ ] No functional regressions: forwarding, duplicate detection, drop reasons unchanged