### PR TITLE
perf(storage): rate-limit WebSocket stats broadcast to once per 5 s

### DIFF
--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -36,6 +36,10 @@ class StorageCollector:
         self.sqlite_handler = SQLiteHandler(self.storage_dir)
         self.rrd_handler = RRDToolHandler(self.storage_dir)
         self.mqtt_handler = MQTTHandler(config.get("mqtt", {}), node_name, node_id)
+        # Rate-limit the heavy WebSocket stats broadcast (get_packet_stats is a
+        # GROUP BY query that can cost several ms on an SD card).  Sending it on
+        # every packet is unnecessary — the dashboard polls every few seconds.
+        self._last_ws_stats_broadcast: float = 0.0
 
         # Initialize LetsMesh handler if configured
         self.letsmesh_handler = None
@@ -201,16 +205,26 @@ class StorageCollector:
         if self.websocket_available:
             try:
                 self.websocket_broadcast_packet(packet_record)
-                packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
-                uptime_seconds = (
-                    time.time() - self.repeater_handler.start_time if self.repeater_handler else 0
-                )
-                self.websocket_broadcast_stats(
-                    {
-                        "packet_stats": packet_stats_24h,
-                        "system_stats": {"uptime_seconds": uptime_seconds},
-                    }
-                )
+
+                # get_packet_stats() is a GROUP BY aggregation over the full
+                # packets table — potentially several ms of SD-card I/O.
+                # Rate-limit the broadcast to at most once every 5 seconds.
+                # The dashboard polls on its own schedule; sub-second freshness
+                # here provides no UX benefit and burns I/O on every packet.
+                now = time.time()
+                if now - self._last_ws_stats_broadcast >= 5.0:
+                    self._last_ws_stats_broadcast = now
+                    packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
+                    uptime_seconds = (
+                        time.time() - self.repeater_handler.start_time
+                        if self.repeater_handler else 0
+                    )
+                    self.websocket_broadcast_stats(
+                        {
+                            "packet_stats": packet_stats_24h,
+                            "system_stats": {"uptime_seconds": uptime_seconds},
+                        }
+                    )
             except Exception as e:
                 logger.debug(f"WebSocket broadcast failed: {e}")
 


### PR DESCRIPTION
## Problem

`_publish_packet_sync()` calls `sqlite_handler.get_packet_stats(hours=24)` unconditionally on **every** received or forwarded packet:

```python
# current rightup code (storage_collector.py ~line 204)
self.websocket_broadcast_packet(packet_record)
packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)   # ← runs every packet
uptime_seconds = ...
self.websocket_broadcast_stats({"packet_stats": packet_stats_24h, ...})
```

`get_packet_stats()` is a `GROUP BY` SQL aggregation over the full `packets` table.  On an SD card with a large table this costs 5–20 ms per call.  At typical mesh traffic rates (10–100 packets/min) this translates to:

- **10 pkt/min** → 10 unnecessary GROUP BY queries/min, ~150 ms wasted SD I/O/min
- **100 pkt/min** → 100 queries/min, ~1.5 s wasted SD I/O/min — competing directly with packet storage writes

The WebSocket dashboard polls on its own schedule (typically every 5–30 seconds).  Sending updated stats at sub-second cadence provides no visible benefit.

## Context

The `fix/combined-optimizations` branch had a `_last_ws_stats_broadcast` timestamp and a 5-second guard.  Rightup's asyncio-task refactor correctly restructured how network I/O is deferred, but the throttle was not carried over into `_publish_packet_sync`.

Note: `websocket_broadcast_packet()` (the lightweight per-packet live-feed event) is **not** throttled — it still fires on every packet as expected.

## Solution

```python
# __init__
self._last_ws_stats_broadcast: float = 0.0

# _publish_packet_sync()
self.websocket_broadcast_packet(packet_record)          # always

now = time.time()
if now - self._last_ws_stats_broadcast >= 5.0:         # rate-limited
    self._last_ws_stats_broadcast = now
    packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
    uptime_seconds = ...
    self.websocket_broadcast_stats({"packet_stats": packet_stats_24h, ...})
```

## Proof of correctness

| Property | Reasoning |
|---|---|
| Monotonic guard | `time.time()` is monotonically non-decreasing under normal conditions. The guard is safe. |
| No data loss | Stats are still delivered every 5 s regardless of traffic rate. A dashboard polling every 10 s sees at most one stale response. |
| Thread safety | `_publish_packet_sync` runs inside `_deferred_publish`, which is an `asyncio.Task` on the event loop — single-threaded cooperative execution. No concurrent mutation of `_last_ws_stats_broadcast`. |
| Fallback path | The `sync_fallback=self._publish_packet_sync` path (test/no-loop contexts) also benefits from the throttle. |

## Impact

| Scenario | Before | After |
|---|---|---|
| 10 pkt/min | 10 GROUP BY queries/min | ≤ 12/min (capped) |
| 60 pkt/min | 60 GROUP BY queries/min | ≤ 12/min |
| 300 pkt/min | 300 GROUP BY queries/min | ≤ 12/min |

## Test plan

- [ ] **Unit — throttle**: mock `sqlite_handler.get_packet_stats` and `websocket_broadcast_stats`; call `_publish_packet_sync` 10 times with 0.1 s gaps; assert `get_packet_stats` called ≤ 2 times.
- [ ] **Unit — first call fires immediately**: fresh `StorageCollector` instance, call `_publish_packet_sync` once; assert `get_packet_stats` called exactly once (no artificial warmup delay).
- [ ] **Unit — broadcast_packet unaffected**: call `_publish_packet_sync` 5 times rapidly; assert `websocket_broadcast_packet` called exactly 5 times.
- [ ] **Integration**: run node under load for 60 s; inspect log or add counter; confirm `get_packet_stats` called ≤ 12 times regardless of packet rate.

## Independence

This PR touches only `repeater/data_acquisition/storage_collector.py`.  It does not depend on any other performance PR and can be merged in any order.