### PR TITLE
fix(api): delay manual advert send like CLI

### DIFF
--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -645,8 +645,13 @@ class APIEndpoints:
                 return self._error("Event loop not available")
             import asyncio
 
-            future = asyncio.run_coroutine_threadsafe(self.send_advert_func(), self.event_loop)
-            result = future.result(timeout=10)
+            async def delayed_advert():
+                """Match CLI advert timing before triggering the radio send."""
+                await asyncio.sleep(1.5)
+                return await self.send_advert_func()
+
+            future = asyncio.run_coroutine_threadsafe(delayed_advert(), self.event_loop)
+            result = future.result(timeout=15)
             return (
                 self._success("Advert sent successfully")
                 if result


### PR DESCRIPTION
## Summary
- Make /api/send_advert use the same 1.5 second delayed send timing as the CLI advert command.
- Await the delayed send coroutine result so the API response still reflects whether the advert send completed.
- Extend the wait timeout slightly to account for the deliberate delay.

## Context
On slow embedded targets, the web dashboard advert path could report success while not producing a confirmed over-air advert, while the CLI advert command worked reliably because it delayed the radio send by 1.5 seconds. This aligns the API path with that known-good CLI behavior.

## Verification
- python3 -m compileall -q repeater
- git diff --check
- python3 -m pytest -q could not run locally because pytest is not installed in the active Python environment.