### PR TITLE
Fix Buildroot OTA updates to use the repo upgrade path

### DIFF
--- a/buildroot-manage.sh
+++ b/buildroot-manage.sh
@@ -622,6 +622,21 @@ PY
     info "Linked image-provided Python runtime into the venv"
 }
 
+remove_shadowing_buildroot_native_packages() {
+    local removed=0
+
+    if "$VENV_PIP" show python-periphery >/dev/null 2>&1; then
+        stage "Restoring Buildroot GPIO runtime"
+        info "Removing venv-installed python-periphery so the image-provided package is used"
+        "$VENV_PIP" uninstall -y python-periphery >/dev/null 2>&1 || true
+        removed=1
+    fi
+
+    if [ "$removed" -eq 0 ]; then
+        info "No shadowing Buildroot native GPIO wheels found in the venv"
+    fi
+}
+
 install_core_into_venv() {
     local core_repo core_ref core_spec
 
@@ -1361,6 +1376,7 @@ install_repeater() {
     install_buildroot_dependencies
     install_core_into_venv
     install_repeater_package
+    remove_shadowing_buildroot_native_packages
     link_system_site_packages
 
     stage "Validating installed runtime"
@@ -1426,6 +1442,7 @@ upgrade_repeater() {
         ensure_yq >/dev/null 2>&1 || true
         install_repeater_package
     fi
+    remove_shadowing_buildroot_native_packages
     link_system_site_packages
     stage "Validating installed runtime"
     if check_venv_runtime; then

--- a/buildroot-manage.sh
+++ b/buildroot-manage.sh
@@ -24,6 +24,8 @@ R2_ENABLED=1
 YQ_VERSION="${YQ_VERSION:-v4.44.3}"
 PYMC_CORE_REPO="${PYMC_CORE_REPO:-https://github.com/rightup/pyMC_core.git}"
 PYMC_CORE_REF="${PYMC_CORE_REF:-}"
+PYMC_CORE_LOCAL_DIR="${PYMC_CORE_LOCAL_DIR:-}"
+PYMC_SKIP_BUILDROOT_DEP_INSTALL="${PYMC_SKIP_BUILDROOT_DEP_INSTALL:-0}"
 RADIO_SETTINGS_JSON="$SCRIPT_DIR/radio-settings.json"
 RADIO_PRESETS_JSON="$SCRIPT_DIR/radio-presets.json"
 BUILDROOT_RADIO_SETTINGS_JSON="$SCRIPT_DIR/radio-settings-buildroot.json"
@@ -533,6 +535,15 @@ install_buildroot_dependencies() {
     local wheel_base
     local deps
 
+    if [ "${PYMC_SKIP_BUILDROOT_DEP_INSTALL}" = "1" ]; then
+        stage "Checking embedded Python dependency baseline"
+        if check_buildroot_dependencies_installed >/dev/null 2>&1; then
+            info "Image-provided Python dependency wheels already satisfy Buildroot requirements"
+            return 0
+        fi
+        fail "Embedded/offline install requested, but the required Python dependency wheels are not already present in the image."
+    fi
+
     wheel_base=$(get_r2_wheel_base 2>/dev/null || true)
     deps=$(set_wheel_dependencies)
     stage "Installing Python dependency wheels"
@@ -613,6 +624,14 @@ PY
 
 install_core_into_venv() {
     local core_repo core_ref core_spec
+
+    if [ -n "$PYMC_CORE_LOCAL_DIR" ]; then
+        [ -d "$PYMC_CORE_LOCAL_DIR" ] || fail "Missing local pyMC_core checkout: $PYMC_CORE_LOCAL_DIR"
+        stage "Installing pyMC_core"
+        info "Local dir: ${PYMC_CORE_LOCAL_DIR}"
+        "$VENV_PIP" install --upgrade --no-cache-dir --no-deps --no-build-isolation "$PYMC_CORE_LOCAL_DIR"
+        return 0
+    fi
 
     core_repo="$PYMC_CORE_REPO"
     case "$core_repo" in

--- a/repeater/web/update_endpoints.py
+++ b/repeater/web/update_endpoints.py
@@ -59,6 +59,18 @@ def _get_github_ssl_context() -> ssl.SSLContext:
     return _github_ssl_ctx
 
 
+def _find_buildroot_upgrade_helper() -> Optional[str]:
+    candidates = [
+        "/root/pyMC_Repeater/buildroot-manage.sh",
+        "/opt/pymc_repeater/pyMC_Repeater/buildroot-manage.sh",
+        "/root/scripts/buildroot-manage.sh",
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
 class _RateLimitError(Exception):
     """Raised when GitHub returns HTTP 403 due to rate limiting."""
     def __init__(self, msg: str, reset_at: Optional[datetime] = None):
@@ -809,16 +821,16 @@ def _do_install() -> None:
     _state.append_line(f"[pyMC updater] Installing from channel '{channel}'…")
 
     _UPGRADE_WRAPPER = "/usr/local/bin/pymc-do-upgrade"
-    _BUILDROOT_UPGRADE_HELPER = "/root/scripts/buildroot-manage.sh"
+    _BUILDROOT_UPGRADE_HELPER = _find_buildroot_upgrade_helper()
     is_root = (_os.geteuid() == 0)
 
     if is_root and is_buildroot():
         env["PYMC_REPEATER_REF"] = channel
         env["PYMC_CORE_REF"] = channel
-        _state.append_line(f"[pyMC updater] Buildroot image detected – using {_BUILDROOT_UPGRADE_HELPER}")
-        if not os.path.isfile(_BUILDROOT_UPGRADE_HELPER):
-            _state.finish_install(False, f"Buildroot upgrade helper not found at {_BUILDROOT_UPGRADE_HELPER}")
+        if not _BUILDROOT_UPGRADE_HELPER:
+            _state.finish_install(False, "Buildroot upgrade helper not found in repo checkout or image bootstrap paths")
             return
+        _state.append_line(f"[pyMC updater] Buildroot image detected – using {_BUILDROOT_UPGRADE_HELPER}")
         cmd = ["/bin/sh", _BUILDROOT_UPGRADE_HELPER, "upgrade"]
     elif is_root:
         _migrate_service_unit()

--- a/repeater/web/update_endpoints.py
+++ b/repeater/web/update_endpoints.py
@@ -29,6 +29,7 @@ from datetime import datetime
 from typing import List, Optional
 
 import cherrypy
+from repeater.service_utils import is_buildroot
 
 logger = logging.getLogger("HTTPServer")
 
@@ -808,9 +809,18 @@ def _do_install() -> None:
     _state.append_line(f"[pyMC updater] Installing from channel '{channel}'…")
 
     _UPGRADE_WRAPPER = "/usr/local/bin/pymc-do-upgrade"
+    _BUILDROOT_UPGRADE_HELPER = "/root/scripts/buildroot-manage.sh"
     is_root = (_os.geteuid() == 0)
 
-    if is_root:
+    if is_root and is_buildroot():
+        env["PYMC_REPEATER_REF"] = channel
+        env["PYMC_CORE_REF"] = channel
+        _state.append_line(f"[pyMC updater] Buildroot image detected – using {_BUILDROOT_UPGRADE_HELPER}")
+        if not os.path.isfile(_BUILDROOT_UPGRADE_HELPER):
+            _state.finish_install(False, f"Buildroot upgrade helper not found at {_BUILDROOT_UPGRADE_HELPER}")
+            return
+        cmd = ["/bin/sh", _BUILDROOT_UPGRADE_HELPER, "upgrade"]
+    elif is_root:
         _migrate_service_unit()
 
         # Ensure venv exists (migration from system-pip era)


### PR DESCRIPTION
## Fix: Buildroot/Luckfox OTA Upgrade Path

This PR fixes the Buildroot/Luckfox OTA upgrade flow so WebUI updates use the repo’s Buildroot upgrade logic instead of the generic root pip path.

---

## What Was Wrong

- On Buildroot images, the WebUI updater was still using the generic “run pip install as root” path
- This bypassed Buildroot-specific install logic and could introduce incompatible packages into the venv
- On Luckfox, this allowed `python-periphery` to be upgraded inside the venv, which:
  - Shadowed the image-provided GPIO runtime
  - Broke SX1262 GPIO initialization after OTA restart

---

## What Changed

### repeater/web/update_endpoints.py

- When running as root on a Buildroot image:
  - Uses the Buildroot upgrade helper instead of the generic pip install path
- Helper resolution order:
  - /root/pyMC_Repeater/buildroot-manage.sh
  - /opt/pymc_repeater/pyMC_Repeater/buildroot-manage.sh
  - /root/scripts/buildroot-manage.sh (fallback)

---

### buildroot-manage.sh

- During install/upgrade:
  - Removes any venv-installed python-periphery if present
- Ensures the image-provided system package remains authoritative
- Prevents venv shadowing of the known-good GPIO runtime

---

## Why This Is Correct

- Buildroot/Luckfox already has a dedicated install/upgrade path for:
  - Image-provided native modules
  - Buildroot-specific runtime assumptions
  - Custom service/init behavior
- OTA should reuse this path instead of introducing a second install model via root pip
- Preferring the repo checkout helper allows newer repo logic to fix upgrade behavior even on older images

---

## Behavior After This Change

- WebUI OTA now follows the same logic as: buildroot-manage.sh upgrade
- Repo-based upgrade logic takes precedence over baked image behavior
- The venv no longer retains a shadowing python-periphery that can break GPIO on restart

---

## Validation

- Syntax checks:
  - python3 -m py_compile repeater/web/update_endpoints.py repeater/service_utils.py
  - bash -n buildroot-manage.sh

- Live hardware validation on Luckfox Buildroot:
  - Reproduced the broken OTA state
  - Removed shadowing venv python-periphery
  - Ran the Buildroot upgrade path successfully
  - Confirmed repeater came back up
  - Confirmed periphery is loaded from /usr/lib/python3.11/site-packages
  - Verified updater now prefers /root/pyMC_Repeater/buildroot-manage.sh