### PR TITLE
fix(db): add migration to backfill room_messages.created_at on old schemas

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -567,6 +567,29 @@ class SQLiteHandler:
                     )
                     logger.info(f"Migration '{migration_name}' applied successfully")
 
+                # Migration 10: Add created_at column to room_messages for old DB schemas.
+                # The column was added to the CREATE TABLE statement but existing databases
+                # that were created before this change will be missing it, causing every
+                # INSERT to fail with "table room_messages has no column named created_at".
+                migration_name = "room_messages_created_at"
+                existing = conn.execute(
+                    "SELECT migration_name FROM migrations WHERE migration_name = ?",
+                    (migration_name,),
+                ).fetchone()
+                if not existing:
+                    cursor = conn.execute("PRAGMA table_info(room_messages)")
+                    room_msg_columns = [col[1] for col in cursor.fetchall()]
+                    if room_msg_columns and "created_at" not in room_msg_columns:
+                        conn.execute(
+                            "ALTER TABLE room_messages ADD COLUMN created_at REAL NOT NULL DEFAULT 0"
+                        )
+                        logger.info("Migration 10: Added created_at column to room_messages")
+                    conn.execute(
+                        "INSERT INTO migrations (migration_name, applied_at) VALUES (?, ?)",
+                        (migration_name, time.time()),
+                    )
+                    logger.info(f"Migration '{migration_name}' applied successfully")
+
                 conn.commit()
 
         except Exception as e:


### PR DESCRIPTION
## Problem

Databases created before `created_at` was added to the `CREATE TABLE room_messages` statement are missing the column. SQLite's `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables, so the schema change is never applied automatically.

Every `INSERT INTO room_messages` then fails:

```
OperationalError: table room_messages has no column named created_at
```

This propagates as:
- `insert_room_message()` → returns `None`
- `add_post()` → returns `False`
- Web API → `"Failed to add message (rate limit or validation error)"`
- Web UI room view → `"No messages yet"` (nothing was ever stored)

The companion still shows **"Delivered ✓"** because the ACK is dispatched as a background task _before_ `add_post()` is ever called — delivery acknowledgement and storage are fully decoupled.

## Solution

Migration 10 runs `PRAGMA table_info(room_messages)` to detect the missing column and issues:

```sql
ALTER TABLE room_messages ADD COLUMN created_at REAL NOT NULL DEFAULT 0
```

Existing rows get `DEFAULT 0`; new rows get `time.time()` from `insert_room_message()` as before.

## How to verify

After restarting the repeater against an old database:
1. Check logs for `"Migration 'room_messages_created_at' applied successfully"`
2. Send a message from the companion — logs should show `"New post #N from ..."` instead of `"Failed to store message to database"`
3. The message appears in the web UI room view

🤖 Generated with [Claude Code](https://claude.com/claude-code)