### PR TITLE
fix(room-server): GlobalRateLimiter never held the lock during transmission

### DIFF
--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -41,32 +41,46 @@ RETRY_BACKOFF_SCHEDULE = [0, 30, 300, 3600]  # 0s, 30s, 5min, 1hr
 
 # Global rate limiter (shared across all rooms)
 _global_push_limiter = None
-_global_push_lock = asyncio.Lock()
-GLOBAL_MIN_GAP_BETWEEN_MESSAGES = 1.1  # 1.1s  minimum gap between transmissions
+GLOBAL_MIN_GAP_BETWEEN_MESSAGES = 1.1  # 1.1s minimum gap between transmissions
 
 
 class GlobalRateLimiter:
+    """Serialise all radio transmissions and enforce a minimum gap between them.
+
+    Usage::
+
+        await limiter.acquire()   # blocks until the radio is free
+        try:
+            await send_packet(...)
+        finally:
+            limiter.release()     # frees the lock for the next caller
+
+    The lock is acquired manually (``await lock.acquire()``) so that it stays
+    held across the ``await send_packet(...)`` call.  Using ``async with`` would
+    release it as soon as ``acquire()`` returned, which is what the previous
+    implementation did — the lock was never actually held during transmission.
+    """
 
     def __init__(self, min_gap_seconds: float = 0.1):
         self.min_gap = min_gap_seconds  # Minimum gap between consecutive messages
         self.lock = asyncio.Lock()  # Only one transmission at a time
-        self.last_release_time = 0
+        self.last_release_time = 0.0
 
     async def acquire(self):
-
-        async with self.lock:
-            # Enforce minimum gap between consecutive transmissions
-            now = time.time()
-            time_since_last = now - self.last_release_time
-            if time_since_last < self.min_gap:
-                wait_time = self.min_gap - time_since_last
-                logger.debug(f"Global rate limiter: waiting {wait_time*1000:.0f}ms")
-                await asyncio.sleep(wait_time)
-            # Lock is now held - caller can transmit
-            # Will be released when context exits
+        # Manually acquire so the lock stays held until release() is called.
+        await self.lock.acquire()
+        # Enforce minimum gap between consecutive transmissions.
+        now = time.time()
+        time_since_last = now - self.last_release_time
+        if time_since_last < self.min_gap:
+            wait_time = self.min_gap - time_since_last
+            logger.debug(f"Global rate limiter: waiting {wait_time*1000:.0f}ms")
+            await asyncio.sleep(wait_time)
+        # Lock is now held — caller must call release() when done.
 
     def release(self):
         self.last_release_time = time.time()
+        self.lock.release()
 
 
 class RoomServer:


### PR DESCRIPTION
## Problem

`GlobalRateLimiter.acquire()` used `async with self.lock:`, which releases the lock the moment the method returns — **before the caller has sent anything**. The comment even said `"Lock is now held"` but it was not.

Consequence: multiple `push_post_to_client()` coroutines could all pass through `acquire()` simultaneously and transmit at the same time, defeating the entire purpose of the limiter. LoRa is a serial medium — overlapping transmissions corrupt each other.

`release()` only updated `last_release_time` but never released any `asyncio.Lock` object (there was nothing to release), so the minimum-gap enforcement between consecutive messages was also broken.

Additionally, `_global_push_lock = asyncio.Lock()` at module level was dead code — never referenced anywhere — and would raise `DeprecationWarning`/`RuntimeError` on Python 3.10+ because `asyncio.Lock()` created outside a running event loop is not attached to any loop.

## Solution

- `acquire()` now calls `await self.lock.acquire()` **manually** so the lock stays held across the caller's `await packet_injector(...)` call in `push_post_to_client()`.
- `release()` calls `self.lock.release()` in addition to recording the timestamp.
- Remove the dead `_global_push_lock` module-level variable.

## How to verify

Under the old code, adding `print("acquired")` at the end of `acquire()` and `print("released")` at the start of `release()`, then triggering two simultaneous pushes, would show both "acquired" lines before either "released" line. After this fix, the second "acquired" cannot appear until the first "released" has printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)