### PR TITLE
fix(room-server): honour allow_server_author to bypass rate limiting for web UI posts

### DIFF
--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -240,27 +240,32 @@ class RoomServer:
                 message_text = message_text[:MAX_MESSAGE_LENGTH]
 
             # SAFETY: Rate limit per client
+            # Server/web-UI authored messages bypass per-client rate limiting
+            # because they are already gate-kept by the web layer and should
+            # never be silently dropped just because the room server's own key
+            # has hit the radio rate-limit window.
             client_key = client_pubkey.hex()
             now = time.time()
 
-            if client_key not in self.client_post_times:
-                self.client_post_times[client_key] = []
+            if not allow_server_author:
+                if client_key not in self.client_post_times:
+                    self.client_post_times[client_key] = []
 
-            # Remove timestamps older than 1 minute
-            self.client_post_times[client_key] = [
-                t for t in self.client_post_times[client_key] if now - t < 60
-            ]
+                # Remove timestamps older than 1 minute
+                self.client_post_times[client_key] = [
+                    t for t in self.client_post_times[client_key] if now - t < 60
+                ]
 
-            # Check rate limit
-            if len(self.client_post_times[client_key]) >= MAX_POSTS_PER_CLIENT_PER_MINUTE:
-                logger.warning(
-                    f"Room '{self.room_name}': Client {client_pubkey[:4].hex()} "
-                    f"exceeded rate limit ({MAX_POSTS_PER_CLIENT_PER_MINUTE} posts/min), dropping message"
-                )
-                return False
+                # Check rate limit
+                if len(self.client_post_times[client_key]) >= MAX_POSTS_PER_CLIENT_PER_MINUTE:
+                    logger.warning(
+                        f"Room '{self.room_name}': Client {client_pubkey[:4].hex()} "
+                        f"exceeded rate limit ({MAX_POSTS_PER_CLIENT_PER_MINUTE} posts/min), dropping message"
+                    )
+                    return False
 
-            # Record this post time
-            self.client_post_times[client_key].append(now)
+                # Record this post time
+                self.client_post_times[client_key].append(now)
 
             # Use our RTC time for post_timestamp
             post_timestamp = time.time()


### PR DESCRIPTION
## Problem

`add_post()` accepts `allow_server_author: bool = False` but never checks it. The parameter was dead code.

The web API passes `allow_server_author=True` when posting on behalf of the room server (e.g. from the web UI message composer), using the room server's own public key as `client_pubkey`. Because the per-client rate-limit window is keyed on `client_pubkey`, these messages count against the room server's own key. After 10 web UI messages in one minute the key hits `MAX_POSTS_PER_CLIENT_PER_MINUTE` and every subsequent web UI post silently returns `False`, surfacing as:

```
"Failed to add message (rate limit or validation error)"
```

## Solution

Wrap the entire rate-limit block in `if not allow_server_author:`. Server / web-UI messages bypass the window entirely and go straight to `insert_room_message()`.

## How to verify

Send 11+ messages rapidly from the web UI message composer. Previously message 11 would fail with the rate-limit error. After this fix all messages succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)