### PR TITLE
fix(room-server): log ERROR when add_post() returns False in _on_message_received

### DIFF
--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -358,6 +358,12 @@ class TextHelper:
                         logger.info(
                             f"Room '{identity_name}': New post from {sender_pubkey[:4].hex()}: {message_text[:50]}"
                         )
+                    else:
+                        logger.error(
+                            f"Room '{identity_name}': add_post() returned False for message from "
+                            f"{sender_pubkey[:4].hex()} — rate-limited, DB error, or schema mismatch. "
+                            f"Message was NOT stored: {message_text[:80]!r}"
+                        )
 
                 except Exception as e:
                     logger.error(f"Error storing room post: {e}", exc_info=True)


### PR DESCRIPTION
## Problem

When a radio message arrived for a room server and `add_post()` returned `False`, the failure was completely silent. The `if success:` branch was skipped and nothing appeared in the logs. It was impossible to distinguish "message stored successfully" from "message silently dropped" without correlating logs across multiple components.

This made diagnosing the schema/rate-limit bugs (PRs #214–#217) much harder than it needed to be.

## Solution

Add an `else` branch that logs at `ERROR` level with:
- Room name
- Sender pubkey prefix (4 bytes hex)
- The dropped message text (up to 80 chars)
- A hint pointing to the three possible causes: rate-limited, DB error, schema mismatch

## How to verify

Before this fix: trigger a storage failure (e.g. on an old DB schema) and search the logs — nothing appears for the failed message. After this fix: the same failure produces a clearly labelled `ERROR` line immediately in the `TextHelper` logger output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)