### PR TITLE
feat: room server — reconnect sync fix, pubkey alias system, name resolution endpoint

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -246,6 +246,18 @@ class SQLiteHandler:
                     "CREATE INDEX IF NOT EXISTS idx_room_client_sync_pending ON room_client_sync(pending_ack_crc)"
                 )
 
+                # Pubkey aliases — admin-assigned names for clients not in adverts
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS pubkey_aliases (
+                        pubkey TEXT NOT NULL PRIMARY KEY,
+                        alias TEXT NOT NULL,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL
+                    )
+                """
+                )
+
                 conn.commit()
                 logger.info(f"SQLite database initialized: {self.sqlite_path}")
 
@@ -566,6 +578,123 @@ class SQLiteHandler:
                         (migration_name, time.time()),
                     )
                     logger.info(f"Migration '{migration_name}' applied successfully")
+
+
+                # Migration 11: Ensure room_client_sync has UNIQUE(room_hash, client_pubkey).
+                # The constraint was always in the CREATE TABLE statement, but databases created
+                # before this table existed will have picked it up correctly on first run.
+                # However, if the table was somehow created without the constraint (e.g. from an
+                # intermediate build), ON CONFLICT(room_hash, client_pubkey) DO UPDATE SET never
+                # fires — every upsert_client_sync call inserts a new row instead of updating the
+                # existing one, so sync_since never advances and the push loop re-sends the same
+                # message to the companion forever.
+                # Fix: recreate the table with the constraint, keeping only the most-recently-
+                # updated row for each (room_hash, client_pubkey) pair.
+                migration_name = "room_client_sync_unique_constraint"
+                existing = conn.execute(
+                    "SELECT migration_name FROM migrations WHERE migration_name = ?",
+                    (migration_name,),
+                ).fetchone()
+
+                if not existing:
+                    # Check whether the UNIQUE constraint already exists via sqlite_master.
+                    idx_check = conn.execute(
+                        """
+                        SELECT COUNT(*) FROM sqlite_master
+                        WHERE type='index'
+                          AND tbl_name='room_client_sync'
+                          AND (sql LIKE '%UNIQUE%' OR name LIKE '%unique%')
+                        """
+                    ).fetchone()[0]
+
+                    if idx_check == 0:
+                        # Rebuild the table with the constraint.
+                        conn.execute(
+                            """
+                            CREATE TABLE room_client_sync_new (
+                                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                room_hash TEXT NOT NULL,
+                                client_pubkey TEXT NOT NULL,
+                                sync_since REAL NOT NULL DEFAULT 0,
+                                pending_ack_crc INTEGER DEFAULT 0,
+                                push_post_timestamp REAL DEFAULT 0,
+                                ack_timeout_time REAL DEFAULT 0,
+                                push_failures INTEGER DEFAULT 0,
+                                last_activity REAL NOT NULL,
+                                updated_at REAL NOT NULL,
+                                UNIQUE(room_hash, client_pubkey)
+                            )
+                            """
+                        )
+                        # Copy only the most-recently-updated row per client.
+                        conn.execute(
+                            """
+                            INSERT INTO room_client_sync_new
+                                (room_hash, client_pubkey, sync_since, pending_ack_crc,
+                                 push_post_timestamp, ack_timeout_time, push_failures,
+                                 last_activity, updated_at)
+                            SELECT room_hash, client_pubkey, sync_since, pending_ack_crc,
+                                   push_post_timestamp, ack_timeout_time, push_failures,
+                                   last_activity, updated_at
+                            FROM room_client_sync
+                            WHERE id IN (
+                                SELECT MAX(id)
+                                FROM room_client_sync
+                                GROUP BY room_hash, client_pubkey
+                            )
+                            """
+                        )
+                        conn.execute("DROP TABLE room_client_sync")
+                        conn.execute(
+                            "ALTER TABLE room_client_sync_new RENAME TO room_client_sync"
+                        )
+                        # Recreate indices on the rebuilt table.
+                        conn.execute(
+                            "CREATE INDEX IF NOT EXISTS idx_room_client_sync_room "
+                            "ON room_client_sync(room_hash, client_pubkey)"
+                        )
+                        conn.execute(
+                            "CREATE INDEX IF NOT EXISTS idx_room_client_sync_pending "
+                            "ON room_client_sync(pending_ack_crc)"
+                        )
+                        logger.info(
+                            "Migration 11: Rebuilt room_client_sync with "
+                            "UNIQUE(room_hash, client_pubkey) constraint"
+                        )
+                    else:
+                        logger.info(
+                            "Migration 11: room_client_sync already has unique constraint, skipping rebuild"
+                        )
+
+                    conn.execute(
+                        "INSERT INTO migrations (migration_name, applied_at) VALUES (?, ?)",
+                        (migration_name, time.time()),
+                    )
+                    logger.info(f"Migration '{migration_name}' applied successfully")
+
+                # Migration 12: Create pubkey_aliases table for admin-assigned client names
+                migration_name = "add_pubkey_aliases_table"
+                existing = conn.execute(
+                    "SELECT migration_name FROM migrations WHERE migration_name = ?",
+                    (migration_name,),
+                ).fetchone()
+
+                if not existing:
+                    conn.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS pubkey_aliases (
+                            pubkey TEXT NOT NULL PRIMARY KEY,
+                            alias TEXT NOT NULL,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        )
+                        """
+                    )
+                    conn.execute(
+                        "INSERT INTO migrations (migration_name, applied_at) VALUES (?, ?)",
+                        (migration_name, time.time()),
+                    )
+                    logger.info("Migration 12: Created pubkey_aliases table")
 
                 conn.commit()
 
@@ -2566,3 +2695,75 @@ class SQLiteHandler:
         except Exception as e:
             logger.error(f"Failed to pop companion message: {e}")
             return None
+
+    # -----------------------------------------------------------------------
+    # Pubkey alias management
+    # -----------------------------------------------------------------------
+
+    def set_pubkey_alias(self, pubkey: str, alias: str) -> bool:
+        """Create or update a human-readable alias for a public key.
+
+        Args:
+            pubkey: Full hex public key string (64 chars / 32 bytes).
+            alias: Display name to associate with this pubkey.
+
+        Returns:
+            True on success.
+        """
+        try:
+            now = time.time()
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO pubkey_aliases (pubkey, alias, created_at, updated_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(pubkey) DO UPDATE SET alias = excluded.alias,
+                                                      updated_at = excluded.updated_at
+                    """,
+                    (pubkey.lower(), alias.strip(), now, now),
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to set pubkey alias: {e}")
+            return False
+
+    def get_pubkey_alias(self, pubkey: str) -> Optional[str]:
+        """Return the alias for a pubkey, or None if not set."""
+        try:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT alias FROM pubkey_aliases WHERE pubkey = ?",
+                    (pubkey.lower(),),
+                ).fetchone()
+                return row[0] if row else None
+        except Exception as e:
+            logger.debug(f"Failed to get pubkey alias: {e}")
+            return None
+
+    def delete_pubkey_alias(self, pubkey: str) -> bool:
+        """Remove the alias for a pubkey. Returns True if a row was deleted."""
+        try:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM pubkey_aliases WHERE pubkey = ?",
+                    (pubkey.lower(),),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+        except Exception as e:
+            logger.error(f"Failed to delete pubkey alias: {e}")
+            return False
+
+    def get_all_pubkey_aliases(self) -> List[dict]:
+        """Return all pubkey aliases ordered by alias name."""
+        try:
+            with self._connect() as conn:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT pubkey, alias, created_at, updated_at FROM pubkey_aliases ORDER BY alias ASC"
+                ).fetchall()
+                return [dict(r) for r in rows]
+        except Exception as e:
+            logger.error(f"Failed to list pubkey aliases: {e}")
+            return []

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -377,15 +377,27 @@ class StorageCollector:
 
     def get_node_name_by_pubkey(self, pubkey: str) -> Optional[str]:
         """
-        Lookup node name from adverts table by public key.
+        Lookup node display name for a public key.
+
+        Resolution order:
+        1. pubkey_aliases table (admin-assigned, highest priority)
+        2. adverts table (LoRa advert broadcasts from hardware devices)
 
         Args:
-            pubkey: Public key in hex string format
+            pubkey: Public key in hex string format (lowercase, 64 chars)
 
         Returns:
-            Node name if found, None otherwise
+            Display name if found, None otherwise
         """
+        if not pubkey:
+            return None
         try:
+            # 1. Check admin-assigned aliases first
+            alias = self.sqlite_handler.get_pubkey_alias(pubkey)
+            if alias:
+                return alias
+
+            # 2. Fall back to adverts table (hardware devices that have broadcast LoRa adverts)
             import sqlite3
 
             with sqlite3.connect(self.sqlite_handler.sqlite_path) as conn:
@@ -397,6 +409,15 @@ class StorageCollector:
         except Exception as e:
             logger.debug(f"Could not lookup node name for {pubkey[:8] if pubkey else 'None'}: {e}")
             return None
+
+    def set_pubkey_alias(self, pubkey: str, alias: str) -> bool:
+        return self.sqlite_handler.set_pubkey_alias(pubkey, alias)
+
+    def delete_pubkey_alias(self, pubkey: str) -> bool:
+        return self.sqlite_handler.delete_pubkey_alias(pubkey)
+
+    def get_all_pubkey_aliases(self) -> list:
+        return self.sqlite_handler.get_all_pubkey_aliases()
 
     def cleanup_old_data(self, days: int = 7):
         self.sqlite_handler.cleanup_old_data(days)

--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -623,18 +623,34 @@ class RoomServer:
                             continue
 
                         if last_activity == 0:
-                            logger.debug(
-                                f"Skipping client 0x{client.id.get_public_key()[0]:02X} (evicted)"
+                            # Client was evicted but has reconnected — restore sync
+                            # state so queued messages get delivered.  Preserve
+                            # sync_since to avoid replaying already-seen messages.
+                            preserved_sync_since = sync_state.get("sync_since", 0)
+                            logger.info(
+                                f"Room '{self.room_name}': Client "
+                                f"0x{client.id.get_public_key()[0]:02X} reconnected after "
+                                f"eviction, restoring sync_since={preserved_sync_since}"
                             )
-                            continue
+                            self.db.upsert_client_sync(
+                                room_hash=f"0x{self.room_hash:02X}",
+                                client_pubkey=client.id.get_public_key().hex(),
+                                sync_since=preserved_sync_since,
+                                last_activity=time.time(),
+                                push_failures=0,
+                                pending_ack_crc=0,
+                            )
+                            sync_since = preserved_sync_since
+                            # Fall through to check for unsynced messages
 
-                        if push_failures >= 3:
+                        elif push_failures >= 3:
                             logger.debug(
                                 f"Skipping client 0x{client.id.get_public_key()[0]:02X} (max failures)"
                             )
                             continue
 
-                        sync_since = sync_state.get("sync_since", 0)
+                        else:
+                            sync_since = sync_state.get("sync_since", 0)
                     else:
                         # Initialize sync state for new client
                         # Use sync_since from ACL client (sent during login) if available

--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -27,6 +27,7 @@ PUSH_ACK_TIMEOUT_FACTOR_MS = 2000
 # Safety limits and protections
 MAX_MESSAGE_LENGTH = 160  # Match C++ MAX_POST_TEXT_LEN (151 bytes for text)
 MAX_POSTS_PER_CLIENT_PER_MINUTE = 10  # Prevent spam
+DEDUP_WINDOW_SECS = 30  # Drop identical (author, text) within this window
 MAX_CLIENTS_PER_ROOM = 50  # From ACL default
 MAX_PUSH_FAILURES = 3  # Evict after this many consecutive failures
 INACTIVE_CLIENT_TIMEOUT = 3600  # Evict after 1 hour inactivity (seconds)
@@ -183,6 +184,7 @@ class RoomServer:
 
         # Safety and monitoring
         self.client_post_times = {}  # Track last N post times per client for rate limiting
+        self._recent_posts: Dict[tuple, float] = {}  # (pubkey_hex, text) → timestamp for dedup
         self.consecutive_sync_errors = 0  # Circuit breaker counter
         self.last_eviction_check = time.time()
         self.eviction_check_interval = 300  # Check every 5 minutes
@@ -242,6 +244,24 @@ class RoomServer:
             # SAFETY: Rate limit per client
             client_key = client_pubkey.hex()
             now = time.time()
+
+            # Deduplicate retransmissions: drop identical (author, text) within the window.
+            # Clients retry when they don't receive an ack quickly enough; without this guard
+            # every retry lands as a separate message in the room.
+            dedup_key = (client_key, message_text)
+            last_seen = self._recent_posts.get(dedup_key, 0)
+            if now - last_seen < DEDUP_WINDOW_SECS:
+                logger.debug(
+                    f"Room '{self.room_name}': Dropping duplicate from "
+                    f"{client_pubkey[:4].hex()} within {DEDUP_WINDOW_SECS}s window"
+                )
+                return False
+            self._recent_posts[dedup_key] = now
+
+            # Evict stale dedup entries to bound memory usage
+            if len(self._recent_posts) > 500:
+                cutoff = now - DEDUP_WINDOW_SECS
+                self._recent_posts = {k: v for k, v in self._recent_posts.items() if v > cutoff}
 
             if client_key not in self.client_post_times:
                 self.client_post_times[client_key] = []

--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -246,40 +246,23 @@ class RoomServer:
             now = time.time()
 
             if not allow_server_author:
-                # Deduplicate retransmissions.  The MeshCore client retransmits the
-                # same message up to 3 times before giving up, each time with the same
-                # sender_timestamp.  We use (author, sender_timestamp) as the primary
-                # key so that ALL retransmissions of the same logical message are caught
-                # regardless of trailing-byte differences in the decoded text (which can
-                # vary because pymc_core decodes invalid bytes as U+FFFD).
-                #
-                # Fall back to (author, normalised_text) + time-window when
-                # sender_timestamp is 0 (e.g. web-API posts or old pymc_core).
-                if sender_timestamp:
-                    dedup_key = (client_key, sender_timestamp)
-                    if dedup_key in self._recent_posts:
-                        logger.debug(
-                            f"Room '{self.room_name}': Dropping duplicate from "
-                            f"{client_pubkey[:4].hex()} (same sender_timestamp={sender_timestamp})"
-                        )
-                        return False
-                    self._recent_posts[dedup_key] = now
-                else:
-                    # Fallback: text + time-window (legacy / web-API path)
-                    dedup_text = message_text.rstrip("\x00�").rstrip()
-                    dedup_key = (client_key, dedup_text)
-                    last_seen = self._recent_posts.get(dedup_key, 0)
-                    if now - last_seen < DEDUP_WINDOW_SECS:
-                        logger.debug(
-                            f"Room '{self.room_name}': Dropping duplicate from "
-                            f"{client_pubkey[:4].hex()} within {DEDUP_WINDOW_SECS}s window"
-                        )
-                        return False
-                    self._recent_posts[dedup_key] = now
+                # Deduplicate retransmissions: drop identical (author, normalised_text)
+                # within DEDUP_WINDOW_SECS.  The MeshCore client retransmits up to 3
+                # times when no ACK is received.  The text.py caller already normalises
+                # the message by stripping null bytes and U+FFFD replacement chars, so
+                # all retransmissions of the same message produce the same text here
+                # regardless of which trailing bytes the firmware appended.
+                dedup_key = (client_key, message_text)
+                last_seen = self._recent_posts.get(dedup_key, 0)
+                if now - last_seen < DEDUP_WINDOW_SECS:
+                    logger.debug(
+                        f"Room '{self.room_name}': Dropping duplicate from "
+                        f"{client_pubkey[:4].hex()} within {DEDUP_WINDOW_SECS}s window"
+                    )
+                    return False
+                self._recent_posts[dedup_key] = now
 
-                # Evict stale dedup entries to bound memory usage.
-                # All entries record the wall-clock time they were first seen (v),
-                # so a single cutoff works for both key shapes.
+                # Evict stale dedup entries to bound memory usage
                 if len(self._recent_posts) > 500:
                     cutoff = now - DEDUP_WINDOW_SECS
                     self._recent_posts = {k: v for k, v in self._recent_posts.items() if v > cutoff}

--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -245,23 +245,44 @@ class RoomServer:
             client_key = client_pubkey.hex()
             now = time.time()
 
-            # Deduplicate retransmissions: drop identical (author, text) within the window.
-            # Clients retry when they don't receive an ack quickly enough; without this guard
-            # every retry lands as a separate message in the room.
-            dedup_key = (client_key, message_text)
-            last_seen = self._recent_posts.get(dedup_key, 0)
-            if now - last_seen < DEDUP_WINDOW_SECS:
-                logger.debug(
-                    f"Room '{self.room_name}': Dropping duplicate from "
-                    f"{client_pubkey[:4].hex()} within {DEDUP_WINDOW_SECS}s window"
-                )
-                return False
-            self._recent_posts[dedup_key] = now
+            if not allow_server_author:
+                # Deduplicate retransmissions.  The MeshCore client retransmits the
+                # same message up to 3 times before giving up, each time with the same
+                # sender_timestamp.  We use (author, sender_timestamp) as the primary
+                # key so that ALL retransmissions of the same logical message are caught
+                # regardless of trailing-byte differences in the decoded text (which can
+                # vary because pymc_core decodes invalid bytes as U+FFFD).
+                #
+                # Fall back to (author, normalised_text) + time-window when
+                # sender_timestamp is 0 (e.g. web-API posts or old pymc_core).
+                if sender_timestamp:
+                    dedup_key = (client_key, sender_timestamp)
+                    if dedup_key in self._recent_posts:
+                        logger.debug(
+                            f"Room '{self.room_name}': Dropping duplicate from "
+                            f"{client_pubkey[:4].hex()} (same sender_timestamp={sender_timestamp})"
+                        )
+                        return False
+                    self._recent_posts[dedup_key] = now
+                else:
+                    # Fallback: text + time-window (legacy / web-API path)
+                    dedup_text = message_text.rstrip("\x00�").rstrip()
+                    dedup_key = (client_key, dedup_text)
+                    last_seen = self._recent_posts.get(dedup_key, 0)
+                    if now - last_seen < DEDUP_WINDOW_SECS:
+                        logger.debug(
+                            f"Room '{self.room_name}': Dropping duplicate from "
+                            f"{client_pubkey[:4].hex()} within {DEDUP_WINDOW_SECS}s window"
+                        )
+                        return False
+                    self._recent_posts[dedup_key] = now
 
-            # Evict stale dedup entries to bound memory usage
-            if len(self._recent_posts) > 500:
-                cutoff = now - DEDUP_WINDOW_SECS
-                self._recent_posts = {k: v for k, v in self._recent_posts.items() if v > cutoff}
+                # Evict stale dedup entries to bound memory usage.
+                # All entries record the wall-clock time they were first seen (v),
+                # so a single cutoff works for both key shapes.
+                if len(self._recent_posts) > 500:
+                    cutoff = now - DEDUP_WINDOW_SECS
+                    self._recent_posts = {k: v for k, v in self._recent_posts.items() if v > cutoff}
 
             if client_key not in self.client_post_times:
                 self.client_post_times[client_key] = []

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -279,14 +279,11 @@ class TextHelper:
             message_text = packet.decrypted.get("text", "<unknown>")
 
             # Clean message text - remove null bytes, Unicode replacement chars
-            # (U+FFFD appears when the client sends an invalid trailing byte and
-            # pymc_core decodes with errors="replace"), and trailing whitespace.
+            # (U+FFFD / □ appears when the client sends an invalid trailing byte
+            # and pymc_core decodes with errors="replace"), and trailing whitespace.
+            # Normalising here ensures all retransmissions of the same message get
+            # the same text, which is the key the dedup in add_post() compares on.
             message_text = message_text.rstrip("\x00�").rstrip()
-
-            # Use the client's original sender timestamp when available — it is
-            # constant across all retransmissions of the same message, making it
-            # a reliable dedup key.  Fall back to wall clock if not provided.
-            client_sender_timestamp = packet.decrypted.get("sender_timestamp")
 
             logger.info(f"[{identity_type}:{identity_name}] Message: {message_text}")
 
@@ -352,10 +349,8 @@ class TextHelper:
                                 sender_pubkey = client_info.id.get_public_key()
                                 break
 
-                    # Store message as post.
-                    # Prefer the client's own timestamp (constant across retries)
-                    # so that add_post() can use it as a reliable dedup key.
-                    sender_timestamp = client_sender_timestamp or int(time.time())
+                    # Store message as post
+                    sender_timestamp = int(time.time())
                     success = await room_server.add_post(
                         client_pubkey=sender_pubkey,
                         message_text=message_text,

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -278,8 +278,15 @@ class TextHelper:
         if hasattr(packet, "decrypted") and packet.decrypted:
             message_text = packet.decrypted.get("text", "<unknown>")
 
-            # Clean message text - remove null bytes and trailing whitespace
-            message_text = message_text.rstrip("\x00").rstrip()
+            # Clean message text - remove null bytes, Unicode replacement chars
+            # (U+FFFD appears when the client sends an invalid trailing byte and
+            # pymc_core decodes with errors="replace"), and trailing whitespace.
+            message_text = message_text.rstrip("\x00�").rstrip()
+
+            # Use the client's original sender timestamp when available — it is
+            # constant across all retransmissions of the same message, making it
+            # a reliable dedup key.  Fall back to wall clock if not provided.
+            client_sender_timestamp = packet.decrypted.get("sender_timestamp")
 
             logger.info(f"[{identity_type}:{identity_name}] Message: {message_text}")
 
@@ -345,8 +352,10 @@ class TextHelper:
                                 sender_pubkey = client_info.id.get_public_key()
                                 break
 
-                    # Store message as post
-                    sender_timestamp = int(time.time())
+                    # Store message as post.
+                    # Prefer the client's own timestamp (constant across retries)
+                    # so that add_post() can use it as a reliable dedup key.
+                    sender_timestamp = client_sender_timestamp or int(time.time())
                     success = await room_server.add_post(
                         client_pubkey=sender_pubkey,
                         message_text=message_text,

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -124,6 +124,11 @@ logger = logging.getLogger("HTTPServer")
 # DELETE /api/room_message?room_name=General&message_id=123 - Delete specific message
 # DELETE /api/room_messages_clear?room_name=General - Clear all messages in room
 
+# Pubkey Aliases (admin-assigned display names for clients not in adverts table)
+# GET    /api/pubkey_aliases - List all aliases
+# POST   /api/pubkey_alias {"pubkey": "...", "alias": "Alice"} - Set/update alias
+# DELETE /api/pubkey_alias?pubkey=... - Remove alias
+
 # OTA Updates
 # GET    /api/update/status          - Current + latest version, channel, state
 # POST   /api/update/check           - Force fresh GitHub version check
@@ -3813,14 +3818,19 @@ class APIEndpoints:
                 for client in all_clients:
                     try:
                         pub_key = client.id.get_public_key()
+                        pub_key_hex = pub_key.hex()
 
                         # Compute address from public key (first byte of SHA256)
                         address_bytes = CryptoUtils.sha256(pub_key)[:1]
 
+                        # Resolve display name: alias first, then adverts
+                        storage = self._get_storage()
+                        node_name = storage.get_node_name_by_pubkey(pub_key_hex) if storage else None
+
                         clients_list.append(
                             {
                                 "public_key": pub_key[:8].hex() + "..." + pub_key[-4:].hex(),
-                                "public_key_full": pub_key.hex(),
+                                "public_key_full": pub_key_hex,
                                 "address": address_bytes.hex(),
                                 "permissions": "admin" if client.is_admin() else "guest",
                                 "last_activity": client.last_activity,
@@ -3829,6 +3839,7 @@ class APIEndpoints:
                                 "identity_name": identity_info["name"],
                                 "identity_type": identity_info["type"],
                                 "identity_hash": identity_info["hash"],
+                                "node_name": node_name,
                             }
                         )
                     except Exception as client_error:
@@ -5110,6 +5121,78 @@ class APIEndpoints:
             raise
         except Exception as e:
             logger.error(f"DB vacuum error: {e}", exc_info=True)
+            return self._error(str(e))
+
+    # ======================
+    # Pubkey Aliases
+    # ======================
+
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    def pubkey_aliases(self):
+        """List all admin-assigned pubkey aliases.
+
+        GET /api/pubkey_aliases
+
+        Returns:
+            {"success": true, "data": [{"pubkey": "...", "alias": "Alice", ...}, ...]}
+        """
+        self._set_cors_headers()
+        if cherrypy.request.method == "OPTIONS":
+            return ""
+        try:
+            storage = self._get_storage()
+            aliases = storage.get_all_pubkey_aliases()
+            return self._success(aliases)
+        except Exception as e:
+            logger.error(f"Error listing pubkey aliases: {e}", exc_info=True)
+            return self._error(str(e))
+
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    def pubkey_alias(self, pubkey=None):
+        """Create/update or delete a pubkey alias.
+
+        POST /api/pubkey_alias {"pubkey": "<64-char hex>", "alias": "Alice"}
+        DELETE /api/pubkey_alias?pubkey=<64-char hex>
+
+        Returns:
+            {"success": true} or {"success": false, "error": "..."}
+        """
+        self._set_cors_headers()
+        if cherrypy.request.method == "OPTIONS":
+            return ""
+        try:
+            storage = self._get_storage()
+            method = cherrypy.request.method.upper()
+
+            if method == "POST":
+                data = self._parse_json_body()
+                pk = (data.get("pubkey") or "").strip().lower()
+                alias = (data.get("alias") or "").strip()
+                if not pk:
+                    return self._error("pubkey is required")
+                if len(pk) != 64:
+                    return self._error("pubkey must be a 64-character hex string (32 bytes)")
+                if not alias:
+                    return self._error("alias is required")
+                ok = storage.set_pubkey_alias(pk, alias)
+                return self._success({"pubkey": pk, "alias": alias}) if ok else self._error("Failed to save alias")
+
+            elif method == "DELETE":
+                pk = (pubkey or "").strip().lower()
+                if not pk:
+                    return self._error("pubkey query parameter is required")
+                deleted = storage.delete_pubkey_alias(pk)
+                return self._success({"deleted": deleted})
+
+            else:
+                raise cherrypy.HTTPError(405, "Method not allowed")
+
+        except cherrypy.HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error managing pubkey alias: {e}", exc_info=True)
             return self._error(str(e))
 
     # ======================

--- a/tests/test_resolve_pubkey_names_endpoint.py
+++ b/tests/test_resolve_pubkey_names_endpoint.py
@@ -1,0 +1,276 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before loading api_endpoints directly via importlib.
+# This avoids triggering repeater/web/__init__.py which pulls in http_server
+# → cherrypy_cors, a package we don't need in tests.
+# ---------------------------------------------------------------------------
+
+def _pkg(name: str, **attrs) -> types.ModuleType:
+    m = types.ModuleType(name)
+    m.__path__ = []
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    sys.modules.setdefault(name, m)
+    return sys.modules[name]
+
+def _mod(name: str, **attrs) -> types.ModuleType:
+    m = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    sys.modules.setdefault(name, m)
+    return sys.modules[name]
+
+# cherrypy — tools must absorb any attribute access (json_out, gzip, …)
+_tools = MagicMock()
+_tools.json_out.return_value = lambda f: f
+_tools.json_in.return_value = lambda f: f
+_tools.gzip.return_value = lambda f: f
+_cp = _pkg("cherrypy")
+_cp.expose = lambda f: f
+_cp.tools = _tools
+_cp.request = SimpleNamespace(method="GET", json=None, params={})
+_cp.response = SimpleNamespace(headers={})
+_cp.HTTPError = type("HTTPError", (Exception,), {})
+_pkg("cherrypy.lib")
+
+_pkg("pymc_core")
+_pkg("pymc_core.protocol", CryptoUtils=MagicMock(), PacketBuilder=MagicMock())
+_mod("pymc_core.protocol.constants")
+
+# repeater sub-packages / modules that api_endpoints imports from
+_pkg("repeater.companion")
+_mod("repeater.companion.identity_resolve",
+     derive_companion_public_key_hex=MagicMock(),
+     find_companion_index=MagicMock(),
+     heal_companion_empty_names=MagicMock())
+_mod("repeater.config", update_unscoped_flood_policy=MagicMock())
+_mod("repeater.service_utils", get_buildroot_image_info=MagicMock())
+_mod("repeater.config_manager", ConfigManager=MagicMock())
+_pkg("repeater.web")
+_pkg("repeater.web.auth")
+_mod("repeater.web.auth.middleware", require_auth=lambda f: f)
+_mod("repeater.web.auth_endpoints", AuthAPIEndpoints=MagicMock())
+_mod("repeater.web.cad_calibration_engine", CADCalibrationEngine=MagicMock())
+_mod("repeater.web.companion_endpoints", CompanionAPIEndpoints=MagicMock())
+_mod("repeater.web.update_endpoints", UpdateAPIEndpoints=MagicMock())
+
+import repeater as _repeater_pkg  # noqa: E402
+if not hasattr(_repeater_pkg, "__version__"):
+    _repeater_pkg.__version__ = "0.0.0-test"
+
+# Load api_endpoints directly — bypasses repeater/web/__init__.py.
+_ae_path = Path(__file__).parent.parent / "repeater" / "web" / "api_endpoints.py"
+_spec = importlib.util.spec_from_file_location("repeater.web.api_endpoints", _ae_path)
+_ae_mod = importlib.util.module_from_spec(_spec)
+sys.modules["repeater.web.api_endpoints"] = _ae_mod
+_spec.loader.exec_module(_ae_mod)
+
+APIEndpoints = _ae_mod.APIEndpoints
+
+
+# ---------------------------------------------------------------------------
+# Factory — build a minimal APIEndpoints with mocked daemon
+# ---------------------------------------------------------------------------
+
+def _make_api(storage=None, companion_resolver=None):
+    """Return an APIEndpoints instance with mocked daemon and helpers."""
+    daemon = MagicMock()
+    daemon.repeater_handler = MagicMock()
+    daemon.repeater_handler.storage = storage or MagicMock()
+
+    with patch("repeater.web.api_endpoints.CADCalibrationEngine", MagicMock()):
+        api = APIEndpoints.__new__(APIEndpoints)
+
+    api.daemon_instance = daemon
+    api.config = {}
+    api._config_path = "/tmp/test.yaml"
+    api.config_manager = MagicMock()
+    api.auth = MagicMock()
+    api.companion = MagicMock()
+    api.update = MagicMock()
+    api.cad_calibration = MagicMock()
+
+    if companion_resolver is not None:
+        api._get_companion_name_by_pubkey = companion_resolver
+    else:
+        api._get_companion_name_by_pubkey = MagicMock(return_value=None)
+
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestResolvePubkeyNames:
+
+    # -----------------------------------------------------------------------
+    # Happy path — alias-resolved names
+    # -----------------------------------------------------------------------
+
+    def test_known_pubkey_returns_name(self):
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.side_effect = lambda pk: "Alice" if pk == "aa" * 32 else None
+
+        api = _make_api(storage=storage)
+        result = api.resolve_pubkey_names(pubkeys="aa" * 32)
+
+        assert result["success"] is True
+        assert result["data"]["aa" * 32] == "Alice"
+
+    def test_multiple_known_pubkeys_all_resolved(self):
+        pk_a = "aa" * 32
+        pk_b = "bb" * 32
+        name_map = {pk_a: "Alice", pk_b: "Bob"}
+
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.side_effect = lambda pk: name_map.get(pk)
+
+        api = _make_api(storage=storage)
+        result = api.resolve_pubkey_names(pubkeys=f"{pk_a},{pk_b}")
+
+        assert result["success"] is True
+        assert result["data"][pk_a] == "Alice"
+        assert result["data"][pk_b] == "Bob"
+
+    # -----------------------------------------------------------------------
+    # Unknown pubkeys → None in map
+    # -----------------------------------------------------------------------
+
+    def test_unknown_pubkey_value_is_none(self):
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.return_value = None
+
+        api = _make_api(storage=storage)
+        api._get_companion_name_by_pubkey = MagicMock(return_value=None)
+
+        result = api.resolve_pubkey_names(pubkeys="cc" * 32)
+
+        assert result["success"] is True
+        assert result["data"]["cc" * 32] is None
+
+    def test_mix_of_known_and_unknown(self):
+        pk_known = "dd" * 32
+        pk_unknown = "ee" * 32
+
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.side_effect = (
+            lambda pk: "Dave" if pk == pk_known else None
+        )
+
+        api = _make_api(storage=storage)
+        api._get_companion_name_by_pubkey = MagicMock(return_value=None)
+
+        result = api.resolve_pubkey_names(pubkeys=f"{pk_known},{pk_unknown}")
+
+        assert result["success"] is True
+        assert result["data"][pk_known] == "Dave"
+        assert result["data"][pk_unknown] is None
+
+    # -----------------------------------------------------------------------
+    # Empty pubkeys param → empty dict
+    # -----------------------------------------------------------------------
+
+    def test_empty_pubkeys_param_returns_empty_dict(self):
+        api = _make_api()
+        result = api.resolve_pubkey_names(pubkeys="")
+
+        assert result["success"] is True
+        assert result["data"] == {}
+
+    def test_whitespace_only_param_returns_empty_dict(self):
+        api = _make_api()
+        result = api.resolve_pubkey_names(pubkeys="   ,  ,  ")
+
+        assert result["success"] is True
+        assert result["data"] == {}
+
+    # -----------------------------------------------------------------------
+    # Companion-resolved names
+    # -----------------------------------------------------------------------
+
+    def test_companion_name_used_as_fallback(self):
+        pk = "ff" * 32
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.return_value = None  # no alias / advert
+
+        companion_resolver = MagicMock(return_value="CompanionFred")
+        api = _make_api(storage=storage, companion_resolver=companion_resolver)
+
+        result = api.resolve_pubkey_names(pubkeys=pk)
+
+        assert result["success"] is True
+        assert result["data"][pk] == "CompanionFred"
+
+    def test_alias_takes_priority_over_companion(self):
+        pk = "11" * 32
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.return_value = "AliasName"
+
+        companion_resolver = MagicMock(return_value="CompanionName")
+        api = _make_api(storage=storage, companion_resolver=companion_resolver)
+
+        result = api.resolve_pubkey_names(pubkeys=pk)
+
+        assert result["success"] is True
+        assert result["data"][pk] == "AliasName"
+        # Companion resolver must NOT be called if alias already resolved
+        companion_resolver.assert_not_called()
+
+    def test_mix_of_alias_and_companion_resolved(self):
+        pk_alias = "22" * 32
+        pk_companion = "33" * 32
+
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.side_effect = (
+            lambda pk: "AliasUser" if pk == pk_alias else None
+        )
+
+        companion_resolver = MagicMock(
+            side_effect=lambda pk: "CompanionUser" if pk == pk_companion else None
+        )
+        api = _make_api(storage=storage, companion_resolver=companion_resolver)
+
+        result = api.resolve_pubkey_names(pubkeys=f"{pk_alias},{pk_companion}")
+
+        assert result["success"] is True
+        assert result["data"][pk_alias] == "AliasUser"
+        assert result["data"][pk_companion] == "CompanionUser"
+
+    # -----------------------------------------------------------------------
+    # Whitespace trimming in pubkeys param
+    # -----------------------------------------------------------------------
+
+    def test_pubkeys_trimmed_of_whitespace(self):
+        pk = "44" * 32
+        storage = MagicMock()
+        storage.get_node_name_by_pubkey.side_effect = (
+            lambda p: "Trimmed" if p == pk else None
+        )
+
+        api = _make_api(storage=storage)
+        result = api.resolve_pubkey_names(pubkeys=f"  {pk}  ")
+
+        assert result["success"] is True
+        assert result["data"][pk] == "Trimmed"
+
+    # -----------------------------------------------------------------------
+    # Storage unavailable → error response
+    # -----------------------------------------------------------------------
+
+    def test_storage_exception_returns_error(self):
+        api = _make_api()
+        api._get_storage = MagicMock(side_effect=Exception("Storage unavailable"))
+
+        result = api.resolve_pubkey_names(pubkeys="aa" * 32)
+
+        assert result["success"] is False
+        assert "Storage unavailable" in result["error"]

--- a/tests/test_room_server_reconnect.py
+++ b/tests/test_room_server_reconnect.py
@@ -1,0 +1,216 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+# ---------------------------------------------------------------------------
+# Stub pymc_core before loading room_server directly via importlib so we
+# never trigger repeater.handler_helpers.__init__ (which pulls in all other
+# helpers and their deep pymc_core dependencies).
+# ---------------------------------------------------------------------------
+
+def _pkg(name: str, **attrs) -> types.ModuleType:
+    """Register a stub package (with __path__) in sys.modules."""
+    m = types.ModuleType(name)
+    m.__path__ = []
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    sys.modules.setdefault(name, m)
+    return sys.modules[name]
+
+_pkg("pymc_core")
+_pkg("pymc_core.protocol", CryptoUtils=MagicMock(), PacketBuilder=MagicMock())
+_pkg("pymc_core.protocol.constants", PAYLOAD_TYPE_TXT_MSG=0x04)
+
+# Load room_server.py directly — bypasses handler_helpers/__init__.py entirely.
+_rs_path = Path(__file__).parent.parent / "repeater" / "handler_helpers" / "room_server.py"
+_spec = importlib.util.spec_from_file_location("repeater.handler_helpers.room_server", _rs_path)
+_rs_mod = importlib.util.module_from_spec(_spec)
+sys.modules["repeater.handler_helpers.room_server"] = _rs_mod
+_spec.loader.exec_module(_rs_mod)
+
+RoomServer = _rs_mod.RoomServer
+MAX_PUSH_FAILURES = _rs_mod.MAX_PUSH_FAILURES
+POST_SYNC_DELAY_SECS = _rs_mod.POST_SYNC_DELAY_SECS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(pubkey_hex: str = "aa" * 32, sync_since: float = 0.0):
+    client = MagicMock()
+    pubkey_bytes = bytes.fromhex(pubkey_hex)
+    client.id.get_public_key.return_value = pubkey_bytes
+    client.sync_since = sync_since
+    return client
+
+
+def _make_room_server(clients=None, db_sync_state=None, unsynced_messages=None):
+    """Build a RoomServer with fully mocked infrastructure."""
+    local_identity = MagicMock()
+    local_identity.get_public_key.return_value = b"\x01" * 32
+
+    db = MagicMock()
+    acl = MagicMock()
+    packet_injector = AsyncMock()
+
+    clients = clients or []
+    acl.get_all_clients.return_value = clients
+
+    db.get_client_sync.return_value = db_sync_state
+    db.upsert_client_sync.return_value = None
+    db.get_unsynced_messages.return_value = unsynced_messages or []
+    db.get_all_room_clients.return_value = []
+
+    with patch.object(_rs_mod, "_global_push_limiter", None):
+        server = RoomServer(
+            room_hash=0x42,
+            room_name="TestRoom",
+            local_identity=local_identity,
+            sqlite_handler=db,
+            packet_injector=packet_injector,
+            acl=acl,
+            config={},
+        )
+
+    server.db = db
+    server.acl = acl
+    # Start with _running=True; the helper below will stop it after one pass.
+    server._running = True
+    server.consecutive_sync_errors = 0
+    server.next_push_time = 0.0   # Always ready to push
+    server.last_eviction_check = 9_999_999_999.0   # Skip eviction
+    server.last_cleanup_time = 9_999_999_999.0     # Skip cleanup
+
+    return server, db, acl
+
+
+async def _run_one_iteration(server, now=9999.0):
+    """Run _sync_loop for exactly one while-loop iteration.
+
+    The loop body starts with ``await asyncio.sleep(...)``.  We use a
+    side_effect counter so that:
+      - The startup sleep (before the while) is a no-op.
+      - The first sleep *inside* the loop is also a no-op, but sets
+        _running=False so the loop exits after processing.
+    """
+    call_count = 0
+
+    async def _one_shot_sleep(_delay):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:          # 1=startup, 2=first body sleep → stop after
+            server._running = False
+
+    with (
+        patch("asyncio.sleep", side_effect=_one_shot_sleep),
+        patch("time.time", return_value=now),
+        patch("random.uniform", return_value=0.0),
+    ):
+        await server._sync_loop()
+
+
+# ===========================================================================
+# Evicted client (last_activity == 0) — reconnect restore path
+# ===========================================================================
+
+class TestSyncLoopReconnect:
+
+    def test_evicted_client_upsert_called_to_restore(self):
+        pubkey_hex = "bb" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {"pending_ack_crc": 0, "last_activity": 0, "push_failures": 0, "sync_since": 1000.0, "updated_at": 0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        db.upsert_client_sync.assert_called_once()
+        kwargs = db.upsert_client_sync.call_args[1]
+        assert kwargs.get("last_activity", 0) > 0
+        assert kwargs.get("push_failures") == 0
+        assert kwargs.get("pending_ack_crc") == 0
+
+    def test_evicted_client_preserves_sync_since(self):
+        pubkey_hex = "cc" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {"pending_ack_crc": 0, "last_activity": 0, "push_failures": 2, "sync_since": 5000.0, "updated_at": 0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        kwargs = db.upsert_client_sync.call_args[1]
+        assert kwargs.get("sync_since") == 5000.0
+
+    def test_evicted_client_proceeds_to_fetch_messages(self):
+        pubkey_hex = "dd" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {"pending_ack_crc": 0, "last_activity": 0, "push_failures": 0, "sync_since": 0.0, "updated_at": 0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        db.get_unsynced_messages.assert_called_once()
+
+
+class TestSyncLoopMaxFailures:
+
+    def test_max_failure_client_is_skipped(self):
+        pubkey_hex = "ee" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {"pending_ack_crc": 0, "last_activity": 9000.0, "push_failures": MAX_PUSH_FAILURES, "sync_since": 0.0, "updated_at": 8000.0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        db.get_unsynced_messages.assert_not_called()
+
+    def test_failures_one_below_max_not_skipped(self):
+        pubkey_hex = "ff" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {"pending_ack_crc": 0, "last_activity": 9000.0, "push_failures": MAX_PUSH_FAILURES - 1, "sync_since": 0.0, "updated_at": 8000.0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        db.get_unsynced_messages.assert_called_once()
+
+
+class TestSyncLoopNormalClient:
+
+    def test_normal_client_messages_fetched(self):
+        pubkey_hex = "11" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {"pending_ack_crc": 0, "last_activity": 9000.0, "push_failures": 0, "sync_since": 100.0, "updated_at": 8000.0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        db.get_unsynced_messages.assert_called_once()
+
+    def test_message_ready_triggers_push(self):
+        pubkey_hex = "22" * 32
+        client = _make_client(pubkey_hex)
+        now = 9999.0
+        post = {"id": 1, "post_timestamp": now - POST_SYNC_DELAY_SECS - 1, "message_text": "hello", "author_pubkey": pubkey_hex, "txt_type": 0}
+        sync_state = {"pending_ack_crc": 0, "last_activity": 9000.0, "push_failures": 0, "sync_since": 0.0, "updated_at": 8000.0}
+        server, db, _ = _make_room_server(clients=[client], db_sync_state=sync_state, unsynced_messages=[post])
+        with patch.object(server, "push_post_to_client", new_callable=AsyncMock) as mock_push:
+            _run(_run_one_iteration(server, now=now))
+        mock_push.assert_called_once_with(client, post)
+
+    def test_no_clients_skips_message_fetch(self):
+        server, db, _ = _make_room_server(clients=[], unsynced_messages=[])
+        _run(_run_one_iteration(server))
+        db.get_unsynced_messages.assert_not_called()
+
+    def test_pending_ack_client_skipped(self):
+        pubkey_hex = "33" * 32
+        client = _make_client(pubkey_hex)
+        sync_state = {
+            "pending_ack_crc": 0xDEAD,
+            "last_activity": 9000.0,
+            "push_failures": 0,
+            "sync_since": 0.0,
+            "updated_at": 8000.0,
+        }
+        server, db, _ = _make_room_server(
+            clients=[client], db_sync_state=sync_state, unsynced_messages=[]
+        )
+        _run(_run_one_iteration(server))
+        db.get_unsynced_messages.assert_not_called()

--- a/tests/test_room_server_reconnect.py
+++ b/tests/test_room_server_reconnect.py
@@ -224,23 +224,18 @@ class TestSyncLoopNormalClient:
 class TestAddPostDedup:
     """
     Clients retry a message when they don't receive an ack fast enough.
-    The MeshCore client sends the SAME sender_timestamp on every retry of the
-    same message.  add_post() uses (author, sender_timestamp) as the primary
-    dedup key so ALL retransmissions are caught even when the decoded text
-    differs slightly (e.g. a trailing U+FFFD replacement char on one copy).
+    The MeshCore client sends up to 3 copies of the same message.  text.py
+    normalises the decoded text (strips null bytes and U+FFFD replacement chars)
+    before calling add_post(), so all retransmissions of the same message arrive
+    with identical text regardless of trailing-byte differences.
 
-    When sender_timestamp is 0 (web-API path) the fallback is
-    (author, normalised_text) + a time-window.
+    add_post() uses (author, normalised_text) + DEDUP_WINDOW_SECS to drop dupes.
     """
 
     def _make_server_for_add_post(self):
         server, db, _ = _make_room_server()
         db.insert_room_message.return_value = 1
         return server, db
-
-    # ------------------------------------------------------------------
-    # Timestamp-based dedup (primary path — radio retransmissions)
-    # ------------------------------------------------------------------
 
     def test_first_post_is_stored(self):
         server, db = self._make_server_for_add_post()
@@ -250,28 +245,28 @@ class TestAddPostDedup:
         assert result is True
         db.insert_room_message.assert_called_once()
 
-    def test_retry_same_timestamp_is_dropped(self):
-        """Retransmission carries identical sender_timestamp → duplicate."""
+    def test_duplicate_within_window_is_dropped(self):
+        """Retransmission with same normalised text within the window is dropped."""
         server, db = self._make_server_for_add_post()
         pubkey = b"\xbb" * 32
         with patch("time.time", return_value=1000.0):
-            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=42000))
+            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1000))
         db.insert_room_message.reset_mock()
-        # Retry 15 s later — same sender_timestamp, text may differ (trailing U+FFFD)
+        # Retry 15 s later — same normalised text, still inside the 30 s window
         with patch("time.time", return_value=1015.0):
-            result = _run(server.add_post(pubkey, "hello mesh�", sender_timestamp=42000))
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1015))
         assert result is False
         db.insert_room_message.assert_not_called()
 
-    def test_retry_different_timestamp_is_stored(self):
-        """Different sender_timestamp means a genuinely different message."""
+    def test_same_text_after_window_is_accepted(self):
         server, db = self._make_server_for_add_post()
         pubkey = b"\xcc" * 32
         with patch("time.time", return_value=1000.0):
-            _run(server.add_post(pubkey, "hello again", sender_timestamp=42000))
+            _run(server.add_post(pubkey, "hello again", sender_timestamp=1000))
         db.insert_room_message.reset_mock()
-        with patch("time.time", return_value=1060.0):
-            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=42060))
+        # Same text but after the dedup window expires → genuinely new message
+        with patch("time.time", return_value=1000.0 + DEDUP_WINDOW_SECS + 1):
+            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=1031))
         assert result is True
         db.insert_room_message.assert_called_once()
 
@@ -279,30 +274,26 @@ class TestAddPostDedup:
         server, db = self._make_server_for_add_post()
         pubkey = b"\xdd" * 32
         with patch("time.time", return_value=1000.0):
-            _run(server.add_post(pubkey, "message one", sender_timestamp=42001))
+            _run(server.add_post(pubkey, "message one", sender_timestamp=1000))
         db.insert_room_message.reset_mock()
         with patch("time.time", return_value=1001.0):
-            result = _run(server.add_post(pubkey, "message two", sender_timestamp=42002))
+            result = _run(server.add_post(pubkey, "message two", sender_timestamp=1001))
         assert result is True
         db.insert_room_message.assert_called_once()
 
-    def test_same_timestamp_different_authors_both_stored(self):
-        """Same timestamp from two different senders are independent messages."""
+    def test_same_text_different_authors_both_stored(self):
         server, db = self._make_server_for_add_post()
         pubkey_a = b"\xee" * 32
         pubkey_b = b"\xff" * 32
         with patch("time.time", return_value=1000.0):
-            r1 = _run(server.add_post(pubkey_a, "same text", sender_timestamp=42000))
-            r2 = _run(server.add_post(pubkey_b, "same text", sender_timestamp=42000))
+            r1 = _run(server.add_post(pubkey_a, "same text", sender_timestamp=1000))
+            r2 = _run(server.add_post(pubkey_b, "same text", sender_timestamp=1000))
         assert r1 is True
         assert r2 is True
         assert db.insert_room_message.call_count == 2
 
-    # ------------------------------------------------------------------
-    # Text + window fallback (sender_timestamp == 0, e.g. web-API posts)
-    # ------------------------------------------------------------------
-
     def test_fallback_duplicate_within_window_is_dropped(self):
+        """sender_timestamp=0 (web-API path) still uses text-based dedup."""
         server, db = self._make_server_for_add_post()
         pubkey = b"\xa1" * 32
         with patch("time.time", return_value=1000.0):

--- a/tests/test_room_server_reconnect.py
+++ b/tests/test_room_server_reconnect.py
@@ -224,14 +224,23 @@ class TestSyncLoopNormalClient:
 class TestAddPostDedup:
     """
     Clients retry a message when they don't receive an ack fast enough.
-    add_post() should store the first occurrence and silently drop retries
-    that arrive within DEDUP_WINDOW_SECS (30 s) with identical text.
+    The MeshCore client sends the SAME sender_timestamp on every retry of the
+    same message.  add_post() uses (author, sender_timestamp) as the primary
+    dedup key so ALL retransmissions are caught even when the decoded text
+    differs slightly (e.g. a trailing U+FFFD replacement char on one copy).
+
+    When sender_timestamp is 0 (web-API path) the fallback is
+    (author, normalised_text) + a time-window.
     """
 
     def _make_server_for_add_post(self):
         server, db, _ = _make_room_server()
         db.insert_room_message.return_value = 1
         return server, db
+
+    # ------------------------------------------------------------------
+    # Timestamp-based dedup (primary path — radio retransmissions)
+    # ------------------------------------------------------------------
 
     def test_first_post_is_stored(self):
         server, db = self._make_server_for_add_post()
@@ -241,27 +250,28 @@ class TestAddPostDedup:
         assert result is True
         db.insert_room_message.assert_called_once()
 
-    def test_duplicate_within_window_is_dropped(self):
+    def test_retry_same_timestamp_is_dropped(self):
+        """Retransmission carries identical sender_timestamp → duplicate."""
         server, db = self._make_server_for_add_post()
         pubkey = b"\xbb" * 32
         with patch("time.time", return_value=1000.0):
-            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1000))
+            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=42000))
         db.insert_room_message.reset_mock()
-        # Same message 5 seconds later — still within the 30s window
-        with patch("time.time", return_value=1005.0):
-            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1005))
+        # Retry 15 s later — same sender_timestamp, text may differ (trailing U+FFFD)
+        with patch("time.time", return_value=1015.0):
+            result = _run(server.add_post(pubkey, "hello mesh�", sender_timestamp=42000))
         assert result is False
         db.insert_room_message.assert_not_called()
 
-    def test_same_text_after_window_is_accepted(self):
+    def test_retry_different_timestamp_is_stored(self):
+        """Different sender_timestamp means a genuinely different message."""
         server, db = self._make_server_for_add_post()
         pubkey = b"\xcc" * 32
         with patch("time.time", return_value=1000.0):
-            _run(server.add_post(pubkey, "hello again", sender_timestamp=1000))
+            _run(server.add_post(pubkey, "hello again", sender_timestamp=42000))
         db.insert_room_message.reset_mock()
-        # Same message after the window expires
-        with patch("time.time", return_value=1000.0 + DEDUP_WINDOW_SECS + 1):
-            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=1031))
+        with patch("time.time", return_value=1060.0):
+            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=42060))
         assert result is True
         db.insert_room_message.assert_called_once()
 
@@ -269,20 +279,47 @@ class TestAddPostDedup:
         server, db = self._make_server_for_add_post()
         pubkey = b"\xdd" * 32
         with patch("time.time", return_value=1000.0):
-            _run(server.add_post(pubkey, "message one", sender_timestamp=1000))
+            _run(server.add_post(pubkey, "message one", sender_timestamp=42001))
         db.insert_room_message.reset_mock()
         with patch("time.time", return_value=1001.0):
-            result = _run(server.add_post(pubkey, "message two", sender_timestamp=1001))
+            result = _run(server.add_post(pubkey, "message two", sender_timestamp=42002))
         assert result is True
         db.insert_room_message.assert_called_once()
 
-    def test_same_text_different_authors_both_stored(self):
+    def test_same_timestamp_different_authors_both_stored(self):
+        """Same timestamp from two different senders are independent messages."""
         server, db = self._make_server_for_add_post()
         pubkey_a = b"\xee" * 32
         pubkey_b = b"\xff" * 32
         with patch("time.time", return_value=1000.0):
-            r1 = _run(server.add_post(pubkey_a, "same text", sender_timestamp=1000))
-            r2 = _run(server.add_post(pubkey_b, "same text", sender_timestamp=1000))
+            r1 = _run(server.add_post(pubkey_a, "same text", sender_timestamp=42000))
+            r2 = _run(server.add_post(pubkey_b, "same text", sender_timestamp=42000))
         assert r1 is True
         assert r2 is True
         assert db.insert_room_message.call_count == 2
+
+    # ------------------------------------------------------------------
+    # Text + window fallback (sender_timestamp == 0, e.g. web-API posts)
+    # ------------------------------------------------------------------
+
+    def test_fallback_duplicate_within_window_is_dropped(self):
+        server, db = self._make_server_for_add_post()
+        pubkey = b"\xa1" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=0))
+        db.insert_room_message.reset_mock()
+        with patch("time.time", return_value=1005.0):
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=0))
+        assert result is False
+        db.insert_room_message.assert_not_called()
+
+    def test_fallback_same_text_after_window_is_accepted(self):
+        server, db = self._make_server_for_add_post()
+        pubkey = b"\xa2" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello again", sender_timestamp=0))
+        db.insert_room_message.reset_mock()
+        with patch("time.time", return_value=1000.0 + DEDUP_WINDOW_SECS + 1):
+            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=0))
+        assert result is True
+        db.insert_room_message.assert_called_once()

--- a/tests/test_room_server_reconnect.py
+++ b/tests/test_room_server_reconnect.py
@@ -39,6 +39,7 @@ _spec.loader.exec_module(_rs_mod)
 RoomServer = _rs_mod.RoomServer
 MAX_PUSH_FAILURES = _rs_mod.MAX_PUSH_FAILURES
 POST_SYNC_DELAY_SECS = _rs_mod.POST_SYNC_DELAY_SECS
+DEDUP_WINDOW_SECS = _rs_mod.DEDUP_WINDOW_SECS
 
 
 # ---------------------------------------------------------------------------
@@ -214,3 +215,74 @@ class TestSyncLoopNormalClient:
         )
         _run(_run_one_iteration(server))
         db.get_unsynced_messages.assert_not_called()
+
+
+# ===========================================================================
+# Deduplication of client retransmissions
+# ===========================================================================
+
+class TestAddPostDedup:
+    """
+    Clients retry a message when they don't receive an ack fast enough.
+    add_post() should store the first occurrence and silently drop retries
+    that arrive within DEDUP_WINDOW_SECS (30 s) with identical text.
+    """
+
+    def _make_server_for_add_post(self):
+        server, db, _ = _make_room_server()
+        db.insert_room_message.return_value = 1
+        return server, db
+
+    def test_first_post_is_stored(self):
+        server, db = self._make_server_for_add_post()
+        pubkey = b"\xaa" * 32
+        with patch("time.time", return_value=1000.0):
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1000))
+        assert result is True
+        db.insert_room_message.assert_called_once()
+
+    def test_duplicate_within_window_is_dropped(self):
+        server, db = self._make_server_for_add_post()
+        pubkey = b"\xbb" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1000))
+        db.insert_room_message.reset_mock()
+        # Same message 5 seconds later — still within the 30s window
+        with patch("time.time", return_value=1005.0):
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1005))
+        assert result is False
+        db.insert_room_message.assert_not_called()
+
+    def test_same_text_after_window_is_accepted(self):
+        server, db = self._make_server_for_add_post()
+        pubkey = b"\xcc" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello again", sender_timestamp=1000))
+        db.insert_room_message.reset_mock()
+        # Same message after the window expires
+        with patch("time.time", return_value=1000.0 + DEDUP_WINDOW_SECS + 1):
+            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=1031))
+        assert result is True
+        db.insert_room_message.assert_called_once()
+
+    def test_different_text_from_same_author_is_accepted(self):
+        server, db = self._make_server_for_add_post()
+        pubkey = b"\xdd" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "message one", sender_timestamp=1000))
+        db.insert_room_message.reset_mock()
+        with patch("time.time", return_value=1001.0):
+            result = _run(server.add_post(pubkey, "message two", sender_timestamp=1001))
+        assert result is True
+        db.insert_room_message.assert_called_once()
+
+    def test_same_text_different_authors_both_stored(self):
+        server, db = self._make_server_for_add_post()
+        pubkey_a = b"\xee" * 32
+        pubkey_b = b"\xff" * 32
+        with patch("time.time", return_value=1000.0):
+            r1 = _run(server.add_post(pubkey_a, "same text", sender_timestamp=1000))
+            r2 = _run(server.add_post(pubkey_b, "same text", sender_timestamp=1000))
+        assert r1 is True
+        assert r2 is True
+        assert db.insert_room_message.call_count == 2

--- a/tests/test_sqlite_pubkey_aliases.py
+++ b/tests/test_sqlite_pubkey_aliases.py
@@ -1,0 +1,167 @@
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from repeater.data_acquisition.sqlite_handler import SQLiteHandler
+
+
+# ---------------------------------------------------------------------------
+# Fixture — SQLiteHandler backed by a real in-memory SQLite database
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def db():
+    """Return a SQLiteHandler whose connection is an in-memory SQLite DB."""
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+
+    # Patch sqlite3.connect so that *all* SQLiteHandler._connect calls reuse
+    # this single in-memory connection regardless of the path argument.
+    with patch("repeater.data_acquisition.sqlite_handler.sqlite3.connect", return_value=conn):
+        handler = SQLiteHandler(Path(":memory:"))
+
+    # Force the thread-local to always return our connection so that
+    # subsequent method calls (after __init__) keep using it.
+    handler._local.conn = conn
+    with patch.object(handler, "_connect", return_value=conn):
+        yield handler
+
+    conn.close()
+
+
+# ===========================================================================
+# set_pubkey_alias
+# ===========================================================================
+
+class TestSetPubkeyAlias:
+
+    def test_insert_new_alias_returns_true(self, db):
+        assert db.set_pubkey_alias("aabbcc", "Alice") is True
+
+    def test_inserted_alias_is_retrievable(self, db):
+        db.set_pubkey_alias("aabbcc", "Alice")
+        assert db.get_pubkey_alias("aabbcc") == "Alice"
+
+    def test_upsert_updates_existing_alias(self, db):
+        db.set_pubkey_alias("aabbcc", "Alice")
+        db.set_pubkey_alias("aabbcc", "Bob")
+        assert db.get_pubkey_alias("aabbcc") == "Bob"
+
+    def test_pubkey_stored_lowercase(self, db):
+        db.set_pubkey_alias("AABBCC", "Alice")
+        assert db.get_pubkey_alias("aabbcc") == "Alice"
+
+    def test_alias_stripped_of_whitespace(self, db):
+        db.set_pubkey_alias("aabbcc", "  Alice  ")
+        assert db.get_pubkey_alias("aabbcc") == "Alice"
+
+    def test_multiple_distinct_pubkeys_stored_independently(self, db):
+        db.set_pubkey_alias("aa", "Alice")
+        db.set_pubkey_alias("bb", "Bob")
+        assert db.get_pubkey_alias("aa") == "Alice"
+        assert db.get_pubkey_alias("bb") == "Bob"
+
+
+# ===========================================================================
+# get_pubkey_alias
+# ===========================================================================
+
+class TestGetPubkeyAlias:
+
+    def test_returns_alias_when_found(self, db):
+        db.set_pubkey_alias("deadbeef", "Charlie")
+        assert db.get_pubkey_alias("deadbeef") == "Charlie"
+
+    def test_returns_none_when_not_found(self, db):
+        assert db.get_pubkey_alias("nonexistent") is None
+
+    def test_lookup_case_insensitive_on_pubkey(self, db):
+        db.set_pubkey_alias("deadbeef", "Dave")
+        assert db.get_pubkey_alias("DEADBEEF") == "Dave"
+
+    def test_empty_table_returns_none(self, db):
+        assert db.get_pubkey_alias("anything") is None
+
+
+# ===========================================================================
+# delete_pubkey_alias
+# ===========================================================================
+
+class TestDeletePubkeyAlias:
+
+    def test_delete_existing_returns_true(self, db):
+        db.set_pubkey_alias("aabbcc", "Alice")
+        assert db.delete_pubkey_alias("aabbcc") is True
+
+    def test_deleted_alias_no_longer_retrievable(self, db):
+        db.set_pubkey_alias("aabbcc", "Alice")
+        db.delete_pubkey_alias("aabbcc")
+        assert db.get_pubkey_alias("aabbcc") is None
+
+    def test_delete_nonexistent_returns_false(self, db):
+        assert db.delete_pubkey_alias("doesnotexist") is False
+
+    def test_delete_case_insensitive_on_pubkey(self, db):
+        db.set_pubkey_alias("aabbcc", "Alice")
+        assert db.delete_pubkey_alias("AABBCC") is True
+        assert db.get_pubkey_alias("aabbcc") is None
+
+    def test_delete_one_does_not_affect_others(self, db):
+        db.set_pubkey_alias("aa", "Alice")
+        db.set_pubkey_alias("bb", "Bob")
+        db.delete_pubkey_alias("aa")
+        assert db.get_pubkey_alias("bb") == "Bob"
+
+
+# ===========================================================================
+# get_all_pubkey_aliases
+# ===========================================================================
+
+class TestGetAllPubkeyAliases:
+
+    def test_empty_table_returns_empty_list(self, db):
+        assert db.get_all_pubkey_aliases() == []
+
+    def test_single_entry_returned(self, db):
+        db.set_pubkey_alias("aabb", "Alice")
+        result = db.get_all_pubkey_aliases()
+        assert len(result) == 1
+        assert result[0]["pubkey"] == "aabb"
+        assert result[0]["alias"] == "Alice"
+
+    def test_multiple_entries_all_returned(self, db):
+        db.set_pubkey_alias("cc", "Charlie")
+        db.set_pubkey_alias("aa", "Alice")
+        db.set_pubkey_alias("bb", "Bob")
+        assert len(db.get_all_pubkey_aliases()) == 3
+
+    def test_ordered_by_alias_ascending(self, db):
+        db.set_pubkey_alias("cc", "Zara")
+        db.set_pubkey_alias("aa", "Alice")
+        db.set_pubkey_alias("bb", "Mike")
+        result = db.get_all_pubkey_aliases()
+        aliases = [r["alias"] for r in result]
+        assert aliases == sorted(aliases)
+
+    def test_each_entry_has_required_keys(self, db):
+        db.set_pubkey_alias("aa", "Alice")
+        entry = db.get_all_pubkey_aliases()[0]
+        for key in ("pubkey", "alias", "created_at", "updated_at"):
+            assert key in entry
+
+    def test_after_delete_entry_absent(self, db):
+        db.set_pubkey_alias("aa", "Alice")
+        db.set_pubkey_alias("bb", "Bob")
+        db.delete_pubkey_alias("aa")
+        result = db.get_all_pubkey_aliases()
+        assert len(result) == 1
+        assert result[0]["alias"] == "Bob"
+
+    def test_upsert_does_not_create_duplicate_entries(self, db):
+        db.set_pubkey_alias("aa", "Alice")
+        db.set_pubkey_alias("aa", "Alicia")
+        assert len(db.get_all_pubkey_aliases()) == 1

--- a/tests/test_storage_collector_name_resolution.py
+++ b/tests/test_storage_collector_name_resolution.py
@@ -1,0 +1,171 @@
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+
+nacl_module = types.ModuleType("nacl")
+nacl_signing_module = types.ModuleType("nacl.signing")
+
+
+class _SigningKeyStub:
+    pass
+
+
+nacl_signing_module.SigningKey = _SigningKeyStub
+nacl_module.signing = nacl_signing_module
+
+sys.modules.setdefault("nacl", nacl_module)
+sys.modules.setdefault("nacl.signing", nacl_signing_module)
+
+from repeater.data_acquisition.storage_collector import StorageCollector
+
+
+def _make_collector() -> StorageCollector:
+    with (
+        patch("repeater.data_acquisition.storage_collector.SQLiteHandler"),
+        patch("repeater.data_acquisition.storage_collector.RRDToolHandler"),
+        patch("repeater.data_acquisition.hardware_stats.HardwareStatsCollector"),
+    ):
+        collector = StorageCollector(
+            config={"storage": {"storage_dir": "/tmp/pymc_repeater_test"}}
+        )
+
+    collector.sqlite_handler = MagicMock()
+    collector.sqlite_handler.sqlite_path = Path(":memory:")
+    collector.repeater_handler = SimpleNamespace(start_time=100.0)
+    return collector
+
+
+# ===========================================================================
+# get_node_name_by_pubkey
+# ===========================================================================
+
+class TestGetNodeNameByPubkey:
+
+    # -----------------------------------------------------------------------
+    # Alias takes priority over advert
+    # -----------------------------------------------------------------------
+
+    def test_alias_returned_when_present(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.return_value = "Alice"
+
+        name = collector.get_node_name_by_pubkey("aabbccddeeff0011")
+
+        assert name == "Alice"
+
+    def test_alias_takes_priority_over_advert(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.return_value = "Alias Name"
+
+        # Even if an advert row exists it must not be reached
+        with patch("sqlite3.connect") as mock_connect:
+            name = collector.get_node_name_by_pubkey("aabbccddeeff0011")
+
+        assert name == "Alias Name"
+        mock_connect.assert_not_called()
+
+    # -----------------------------------------------------------------------
+    # Falls back to advert when no alias
+    # -----------------------------------------------------------------------
+
+    def test_falls_back_to_advert_when_no_alias(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.return_value = None
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = ("NodeAlpha",)
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            name = collector.get_node_name_by_pubkey("aabbccddeeff0011")
+
+        assert name == "NodeAlpha"
+
+    def test_advert_query_uses_correct_pubkey(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.return_value = None
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = ("NodeBeta",)
+
+        pubkey = "deadbeef12345678"
+        with patch("sqlite3.connect", return_value=mock_conn):
+            collector.get_node_name_by_pubkey(pubkey)
+
+        call_args = mock_conn.execute.call_args
+        assert pubkey in call_args[0][1]
+
+    # -----------------------------------------------------------------------
+    # Returns None when neither source has a name
+    # -----------------------------------------------------------------------
+
+    def test_returns_none_when_no_alias_and_no_advert(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.return_value = None
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = None
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            name = collector.get_node_name_by_pubkey("aabbccddeeff0011")
+
+        assert name is None
+
+    def test_returns_none_when_advert_row_has_no_name(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.return_value = None
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = None
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            name = collector.get_node_name_by_pubkey("aabbccddeeff0011")
+
+        assert name is None
+
+    # -----------------------------------------------------------------------
+    # Empty / None pubkey input
+    # -----------------------------------------------------------------------
+
+    def test_returns_none_for_none_pubkey(self):
+        collector = _make_collector()
+        name = collector.get_node_name_by_pubkey(None)
+        assert name is None
+
+    def test_returns_none_for_empty_string_pubkey(self):
+        collector = _make_collector()
+        name = collector.get_node_name_by_pubkey("")
+        assert name is None
+
+    def test_alias_handler_not_called_for_empty_pubkey(self):
+        collector = _make_collector()
+        collector.get_node_name_by_pubkey("")
+        collector.sqlite_handler.get_pubkey_alias.assert_not_called()
+
+    def test_alias_handler_not_called_for_none_pubkey(self):
+        collector = _make_collector()
+        collector.get_node_name_by_pubkey(None)
+        collector.sqlite_handler.get_pubkey_alias.assert_not_called()
+
+    # -----------------------------------------------------------------------
+    # Exception resilience
+    # -----------------------------------------------------------------------
+
+    def test_returns_none_on_sqlite_exception(self):
+        collector = _make_collector()
+        collector.sqlite_handler.get_pubkey_alias.side_effect = Exception("db error")
+
+        name = collector.get_node_name_by_pubkey("aabbccddeeff0011")
+
+        assert name is None


### PR DESCRIPTION
## Summary

Four improvements to the room server, each independently useful:

### 1. Fix: queued messages not delivered after client eviction (`room_server.py`)

When a client's `last_activity` is `0` (evicted by the inactivity timer), reconnecting clients were silently skipped by the sync loop — their `push_failures` counter had already hit `MAX_PUSH_FAILURES` and the loop checked that guard before checking for a reconnect. Messages queued during their absence were never delivered.

Fix: detect reconnect first (active client + `last_activity == 0`), reset `push_failures` and restore `last_activity`, then continue to the normal push path.

### 2. Fix: deduplicate client retransmissions (`room_server.py`)

Clients retry a message when they don't receive an ack fast enough — common for distant nodes with weak signal. Without deduplication every retry lands as a separate message in the room.

Add an in-memory `_recent_posts` cache keyed on `(pubkey_hex, message_text)`. Any identical (author, text) pair arriving within `DEDUP_WINDOW_SECS` (30 s) is silently dropped. Cache is evicted when it grows past 500 entries to bound memory usage. Server-authored messages (web UI posts) bypass the check via the existing `allow_server_author` flag.

### 3. Feat: pubkey alias system (`sqlite_handler.py`, `storage_collector.py`, `api_endpoints.py`)

Phone-app users connecting via the room server protocol never broadcast LoRa adverts, so their messages always appear as an unresolved pubkey. This adds a `pubkey_aliases` table so admins can manually assign display names.

- `pubkey_aliases` table created on DB init; migration 12 for existing databases
- `get_node_name_by_pubkey()` on `StorageCollector` checks aliases first (highest priority), then falls back to the adverts table
- New endpoints:
  - `GET /api/pubkey_aliases` — list all aliases
  - `POST /api/pubkey_alias` — set alias `{pubkey, alias}`
  - `DELETE /api/pubkey_alias?pubkey=...` — remove alias
  - `GET /api/resolve_pubkey_names?pubkeys=a,b,c` — lightweight batch lookup for the UI poll cycle, returns `{pubkey: name|null}` map
- `GET /api/acl_clients` response now includes `node_name` (alias → advert fallback) for each connected client

### 4. Test coverage (`tests/`)

58 new tests across 4 files:

| File | Tests | Coverage |
|------|-------|----------|
| `test_sqlite_pubkey_aliases.py` | 22 | CRUD against real in-memory SQLite |
| `test_storage_collector_name_resolution.py` | 11 | alias-first priority chain, fallback, None cases |
| `test_room_server_reconnect.py` | 14 | eviction/reconnect sync loop, max-failure skip, normal push, dedup (5 cases) |
| `test_resolve_pubkey_names_endpoint.py` | 12 | batch resolution, companion fallback, alias priority, error handling |

Tests use `importlib.util.spec_from_file_location` to load modules directly, bypassing `__init__.py` chains that pull in unavailable hardware dependencies.

---

## UI changes

Companion UI PR: https://github.com/tjdownes/pyMC-RepeaterUI/pull/1 (draft, targeting pyMC-dev/pyMC-RepeaterUI)

Per discussion with @RightUp, built UI assets are **not** included here — the UI source PR should be reviewed and built separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)