### PR TITLE
Fix up the CapabilityBoundingSet to allow changing the GID and UID as…

### DIFF
--- a/pymc-repeater.service
+++ b/pymc-repeater.service
@@ -3,8 +3,9 @@
 
 [Unit]
 Description=pyMC Repeater Daemon
-After=network-online.target
+After=network-online.target dbus.socket
 Wants=network-online.target
+Requires=dbus.socket
 
 [Service]
 Type=simple
@@ -34,8 +35,8 @@ SyslogIdentifier=pymc-repeater
 ReadWritePaths=/var/log/pymc_repeater /var/lib/pymc_repeater /etc/pymc_repeater
 SupplementaryGroups=plugdev dialout
 
-# Allow GPS time sync to update CLOCK_REALTIME without running as root
-CapabilityBoundingSet=CAP_SYS_TIME
+# Allow GPS time sync to update CLOCK_REALTIME without running as root, also allow changing user via polkit or sudo
+CapabilityBoundingSet=CAP_SYS_TIME CAP_SETUID CAP_SETGID
 AmbientCapabilities=CAP_SYS_TIME
 
 [Install]


### PR DESCRIPTION
Fix service restart on DietPi and other minimal installs

Added Requires=dbus.socket and After=dbus.socket to the service unit to ensure D-Bus is available before pyMC starts. 
On minimal distros like DietPi, D-Bus is not guaranteed to be running, which prevented polkit from authorising service restarts.

Added CAP_SETUID and CAP_SETGID to CapabilityBoundingSet to allow sudo to function correctly as a fallback restart method. This was a latent bug on any system where the polkit path failed and the sudo fallback was attempted.