### PR TITLE
fix: deduplicate MeshCore client retransmissions in room server

### DIFF
--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -27,6 +27,7 @@ PUSH_ACK_TIMEOUT_FACTOR_MS = 2000
 # Safety limits and protections
 MAX_MESSAGE_LENGTH = 160  # Match C++ MAX_POST_TEXT_LEN (151 bytes for text)
 MAX_POSTS_PER_CLIENT_PER_MINUTE = 10  # Prevent spam
+DEDUP_WINDOW_SECS = 30  # Drop identical (author, text) within this window
 MAX_CLIENTS_PER_ROOM = 50  # From ACL default
 MAX_PUSH_FAILURES = 3  # Evict after this many consecutive failures
 INACTIVE_CLIENT_TIMEOUT = 3600  # Evict after 1 hour inactivity (seconds)
@@ -183,6 +184,7 @@ class RoomServer:
 
         # Safety and monitoring
         self.client_post_times = {}  # Track last N post times per client for rate limiting
+        self._recent_posts: Dict[tuple, float] = {}  # (pubkey_hex, text) → timestamp for dedup
         self.consecutive_sync_errors = 0  # Circuit breaker counter
         self.last_eviction_check = time.time()
         self.eviction_check_interval = 300  # Check every 5 minutes
@@ -242,6 +244,24 @@ class RoomServer:
             # SAFETY: Rate limit per client
             client_key = client_pubkey.hex()
             now = time.time()
+
+            # Deduplicate retransmissions: drop identical (author, text) within the window.
+            # Clients retry when they don't receive an ack quickly enough; without this guard
+            # every retry lands as a separate message in the room.
+            dedup_key = (client_key, message_text)
+            last_seen = self._recent_posts.get(dedup_key, 0)
+            if now - last_seen < DEDUP_WINDOW_SECS:
+                logger.debug(
+                    f"Room '{self.room_name}': Dropping duplicate from "
+                    f"{client_pubkey[:4].hex()} within {DEDUP_WINDOW_SECS}s window"
+                )
+                return False
+            self._recent_posts[dedup_key] = now
+
+            # Evict stale dedup entries to bound memory usage
+            if len(self._recent_posts) > 500:
+                cutoff = now - DEDUP_WINDOW_SECS
+                self._recent_posts = {k: v for k, v in self._recent_posts.items() if v > cutoff}
 
             if client_key not in self.client_post_times:
                 self.client_post_times[client_key] = []

--- a/repeater/handler_helpers/text.py
+++ b/repeater/handler_helpers/text.py
@@ -278,8 +278,12 @@ class TextHelper:
         if hasattr(packet, "decrypted") and packet.decrypted:
             message_text = packet.decrypted.get("text", "<unknown>")
 
-            # Clean message text - remove null bytes and trailing whitespace
-            message_text = message_text.rstrip("\x00").rstrip()
+            # Clean message text - remove null bytes, Unicode replacement chars
+            # (U+FFFD / □ appears when the client sends an invalid trailing byte
+            # and pymc_core decodes with errors="replace"), and trailing whitespace.
+            # Normalising here ensures all retransmissions of the same message get
+            # the same text, which is the key the dedup in add_post() compares on.
+            message_text = message_text.rstrip("\x00�").rstrip()
 
             logger.info(f"[{identity_type}:{identity_name}] Message: {message_text}")
 

--- a/tests/test_room_server_dedup.py
+++ b/tests/test_room_server_dedup.py
@@ -1,0 +1,166 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+# ---------------------------------------------------------------------------
+# Stub pymc_core before loading room_server directly via importlib so we
+# never trigger repeater.handler_helpers.__init__ (which pulls in all other
+# helpers and their deep pymc_core dependencies).
+# ---------------------------------------------------------------------------
+
+def _pkg(name: str, **attrs) -> types.ModuleType:
+    """Register a stub package (with __path__) in sys.modules."""
+    m = types.ModuleType(name)
+    m.__path__ = []
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    sys.modules.setdefault(name, m)
+    return sys.modules[name]
+
+_pkg("pymc_core")
+_pkg("pymc_core.protocol", CryptoUtils=MagicMock(), PacketBuilder=MagicMock())
+_pkg("pymc_core.protocol.constants", PAYLOAD_TYPE_TXT_MSG=0x04)
+
+# Load room_server.py directly — bypasses handler_helpers/__init__.py entirely.
+_rs_path = Path(__file__).parent.parent / "repeater" / "handler_helpers" / "room_server.py"
+_spec = importlib.util.spec_from_file_location("repeater.handler_helpers.room_server", _rs_path)
+_rs_mod = importlib.util.module_from_spec(_spec)
+sys.modules["repeater.handler_helpers.room_server"] = _rs_mod
+_spec.loader.exec_module(_rs_mod)
+
+RoomServer = _rs_mod.RoomServer
+DEDUP_WINDOW_SECS = _rs_mod.DEDUP_WINDOW_SECS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_room_server():
+    """Build a RoomServer with fully mocked infrastructure."""
+    local_identity = MagicMock()
+    local_identity.get_public_key.return_value = b"\x01" * 32
+
+    db = MagicMock()
+    acl = MagicMock()
+    packet_injector = AsyncMock()
+
+    acl.get_all_clients.return_value = []
+    db.get_all_room_clients.return_value = []
+    db.insert_room_message.return_value = 1
+
+    with patch.object(_rs_mod, "_global_push_limiter", None):
+        server = RoomServer(
+            room_hash=0x42,
+            room_name="TestRoom",
+            local_identity=local_identity,
+            sqlite_handler=db,
+            packet_injector=packet_injector,
+            acl=acl,
+            config={},
+        )
+
+    server.db = db
+    return server, db
+
+
+# ===========================================================================
+# Deduplication of client retransmissions
+# ===========================================================================
+
+class TestAddPostDedup:
+    """
+    Clients retry a message when they don't receive an ack fast enough.
+    The MeshCore client sends up to 3 copies of the same message.  text.py
+    normalises the decoded text (strips null bytes and U+FFFD replacement chars)
+    before calling add_post(), so all retransmissions of the same message arrive
+    with identical text regardless of trailing-byte differences.
+
+    add_post() uses (author, normalised_text) + DEDUP_WINDOW_SECS to drop dupes.
+    """
+
+    def test_first_post_is_stored(self):
+        server, db = _make_room_server()
+        pubkey = b"\xaa" * 32
+        with patch("time.time", return_value=1000.0):
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1000))
+        assert result is True
+        db.insert_room_message.assert_called_once()
+
+    def test_duplicate_within_window_is_dropped(self):
+        """Retransmission with same normalised text within the window is dropped."""
+        server, db = _make_room_server()
+        pubkey = b"\xbb" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1000))
+        db.insert_room_message.reset_mock()
+        # Retry 15 s later — same normalised text, still inside the 30 s window
+        with patch("time.time", return_value=1015.0):
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=1015))
+        assert result is False
+        db.insert_room_message.assert_not_called()
+
+    def test_same_text_after_window_is_accepted(self):
+        server, db = _make_room_server()
+        pubkey = b"\xcc" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello again", sender_timestamp=1000))
+        db.insert_room_message.reset_mock()
+        # Same text but after the dedup window expires → genuinely new message
+        with patch("time.time", return_value=1000.0 + DEDUP_WINDOW_SECS + 1):
+            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=1031))
+        assert result is True
+        db.insert_room_message.assert_called_once()
+
+    def test_different_text_from_same_author_is_accepted(self):
+        server, db = _make_room_server()
+        pubkey = b"\xdd" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "message one", sender_timestamp=1000))
+        db.insert_room_message.reset_mock()
+        with patch("time.time", return_value=1001.0):
+            result = _run(server.add_post(pubkey, "message two", sender_timestamp=1001))
+        assert result is True
+        db.insert_room_message.assert_called_once()
+
+    def test_same_text_different_authors_both_stored(self):
+        server, db = _make_room_server()
+        pubkey_a = b"\xee" * 32
+        pubkey_b = b"\xff" * 32
+        with patch("time.time", return_value=1000.0):
+            r1 = _run(server.add_post(pubkey_a, "same text", sender_timestamp=1000))
+            r2 = _run(server.add_post(pubkey_b, "same text", sender_timestamp=1000))
+        assert r1 is True
+        assert r2 is True
+        assert db.insert_room_message.call_count == 2
+
+    def test_fallback_duplicate_within_window_is_dropped(self):
+        """sender_timestamp=0 (web-API path) still uses text-based dedup."""
+        server, db = _make_room_server()
+        pubkey = b"\xa1" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello mesh", sender_timestamp=0))
+        db.insert_room_message.reset_mock()
+        with patch("time.time", return_value=1005.0):
+            result = _run(server.add_post(pubkey, "hello mesh", sender_timestamp=0))
+        assert result is False
+        db.insert_room_message.assert_not_called()
+
+    def test_fallback_same_text_after_window_is_accepted(self):
+        server, db = _make_room_server()
+        pubkey = b"\xa2" * 32
+        with patch("time.time", return_value=1000.0):
+            _run(server.add_post(pubkey, "hello again", sender_timestamp=0))
+        db.insert_room_message.reset_mock()
+        with patch("time.time", return_value=1000.0 + DEDUP_WINDOW_SECS + 1):
+            result = _run(server.add_post(pubkey, "hello again", sender_timestamp=0))
+        assert result is True
+        db.insert_room_message.assert_called_once()


### PR DESCRIPTION
## Summary

- The MeshCore client retransmits a message up to 3 times when no ACK is received — without dedup all three land as separate room messages
- Root cause: `pymc_core` decodes bytes with `errors="replace"`, turning invalid trailing bytes into U+FFFD (□). The existing `rstrip("\x00")` didn't strip □, so "Test" and "Test□" had different dedup keys
- Fix 1 (`text.py`): extend rstrip to also strip `�` (□) so all retransmissions of the same message normalise to identical text
- Fix 2 (`room_server.py`): in-memory `_recent_posts` cache keyed on `(author_pubkey_hex, normalised_text)` — identical (author, text) within 30 s is dropped; cache is evicted when it exceeds 500 entries

## Test plan

- [ ] `pytest tests/test_room_server_dedup.py` — 7 tests, all pass
- [ ] Device test: send a message from a weak-signal node, verify only 1 copy appears in the room

🤖 Generated with [Claude Code](https://claude.com/claude-code)