### PR TITLE
Derive Docker image version from git metadata and dispatch HA add-on sync

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,12 +15,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compute package version
+        id: package_version
+        run: |
+          python -m pip install --disable-pip-version-check setuptools_scm
+          version="$(python -m setuptools_scm)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -45,6 +59,8 @@ jobs:
           file: ./dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            PACKAGE_VERSION=${{ steps.package_version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,3 +49,21 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify Home Assistant add-on repository
+        env:
+          DISPATCH_TOKEN: ${{ secrets.HA_ADDON_REPO_DISPATCH_TOKEN }}
+          CHANNEL: ${{ github.ref_name }}
+          REVISION: ${{ github.sha }}
+        run: |
+          if [ -z "${DISPATCH_TOKEN}" ]; then
+            echo "HA_ADDON_REPO_DISPATCH_TOKEN is not set" >&2
+            exit 1
+          fi
+
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            https://api.github.com/repos/pyMC-dev/pyMC-HA-Add-on/dispatches \
+            -d "{\"event_type\":\"sync-upstream-channel\",\"client_payload\":{\"channel\":\"${CHANNEL}\",\"revision\":\"${REVISION}\"}}"

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.12-slim-bookworm
 
+ARG PACKAGE_VERSION=1.0.5
+
 ENV INSTALL_DIR=/opt/pymc_repeater \
     CONFIG_DIR=/etc/pymc_repeater \
     DATA_DIR=/var/lib/pymc_repeater \
     PYTHONUNBUFFERED=1 \
-    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYMC_REPEATER=1.0.5
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYMC_REPEATER=${PACKAGE_VERSION}
 
 # Install runtime dependencies only
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

This updates the Docker publish workflow so published `pyMC_Repeater` images report a real git-derived version instead of the hardcoded `1.0.5`, and notifies the Home Assistant add-on repository after successful `main` or `dev` image publishes.

---

## Changes

* Compute package version in GitHub Actions using `setuptools_scm`
* Pass computed version into the Docker build as:

  * `PACKAGE_VERSION`
* Update Dockerfile to use:

  * `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYMC_REPEATER=${PACKAGE_VERSION}`
* Keep existing `main` and `dev` image tags unchanged
* Dispatch `sync-upstream-channel` to:

  * `pyMC-dev/pyMC-HA-Add-on`
* Trigger dispatch after successful Docker publishes
* Send both:

  * `channel` from `github.ref_name`
  * `revision` from `github.sha`

---

## Why

Before this change, Docker images always reported version `1.0.5`, even when built from newer development commits.

This caused the in-app updater UI to display misleading version information.

This PR also automates Home Assistant add-on synchronization after image publishes, removing the need for manual follow-up version bumps and changelog updates.

---

## Expected Result

* `dev` images report versions such as:

  * `1.0.10.dev83`
* `main` images report the correct git/tag-derived release version
* Successful image publishes on `main` or `dev` automatically trigger the HA add-on sync workflow
