### PR TITLE
ci: restrict docker publish workflow for forks

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,9 +5,19 @@ on:
     branches:
       - main
       - dev
+  workflow_dispatch:
+    inputs:
+      image_repository:
+        description: "Docker image repository to publish to"
+        required: false
+        default: "pymcdev/pymc-repeater"
 
 jobs:
   docker:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.repository == 'rightup/pyMC_Repeater' ||
+      github.repository == 'yellowcooln/pyMC_Repeater'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +56,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: pymcdev/pymc-repeater
+          images: ${{ github.event_name == 'workflow_dispatch' && inputs.image_repository || 'pymcdev/pymc-repeater' }}
           tags: |
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
@@ -67,6 +77,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify Home Assistant add-on repository
+        if: github.repository == 'rightup/pyMC_Repeater'
         env:
           DISPATCH_TOKEN: ${{ secrets.HA_ADDON_REPO_DISPATCH_TOKEN }}
           CHANNEL: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
This changes the Docker publish workflow so normal automatic image builds still happen on `main` and `dev`, but only in the upstream repo and the maintained fork.

That stops users from accidentally running the Docker publish action just because they made a fork or synced their fork with upstream.

It also keeps a manual path available:
- `workflow_dispatch` is enabled
- users can pick the branch in the GitHub Actions UI
- users can override the target Docker image repository for their own manual publish runs

## What Changed
- kept automatic `push` triggers for `main` and `dev`
- gated the Docker publish job so automatic runs only execute in:
  - `rightup/pyMC_Repeater`
  - `yellowcooln/pyMC_Repeater`
- added a manual `workflow_dispatch` trigger with an `image_repository` input
- limited the Home Assistant add-on dispatch step to the upstream repo only

## Impact
- upstream keeps its normal automated Docker publishing flow
- the maintained fork keeps its normal automated Docker publishing flow
- random forks no longer publish images automatically on fork/sync activity
- fork owners can still run the workflow manually if they intentionally want to publish somewhere else

## Validation
- reviewed the workflow diff locally
- no runtime tests were run
