### PR TITLE
docker: install rrdtool for runtime python

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -21,7 +21,8 @@ ENV INSTALL_DIR=/opt/pymc_repeater \
 # Install runtime dependencies only
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     libffi-dev \
-    python3-rrdtool \
+    librrd-dev \
+    pkg-config \
     jq \
     wget \
     libusb-1.0-0 \
@@ -64,7 +65,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 USER ${USER}
 
 # Install package
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir ".[rrd]"
 
 USER root
 


### PR DESCRIPTION
Fixed docker image from not showing Performance Metrics in the /stats page.

Before:
<img width="1525" height="529" alt="image" src="https://github.com/user-attachments/assets/348f5c36-41e6-405d-be13-cc85c6cf54fa" />

After: 
<img width="1679" height="367" alt="{31F32913-11ED-42D0-9087-0F4E19FBF070}" src="https://github.com/user-attachments/assets/a44dc5f6-875d-4f25-9a4b-3e1ce69affe3" />
