### PR TITLE
Updated settings for Nebra Hat Duo E22P 1W

### DIFF
--- a/radio-settings.json
+++ b/radio-settings.json
@@ -195,7 +195,7 @@
       "rxen_pin": 1,
       "txled_pin": -1,
       "rxled_pin": -1,
-      "tx_power": 22,
+      "tx_power": 18,
       "use_dio3_tcxo": true,
       "use_dio2_rf": true,
       "preamble_length": 17


### PR DESCRIPTION
The github for this hat recommends max of 18. https://github.com/wehooper4/Meshtastic-Hardware/blob/f9b3bb19bbbae8d556127b5ce5bea224b76681ea/NebraHat/Duo/NebraHat_Duo_E22P.yaml#L7