### PR TITLE
MeshSmith: Change tx_power from 22 to 18

### DIFF
--- a/radio-settings.json
+++ b/radio-settings.json
@@ -60,7 +60,7 @@
       "rxen_pin": 12,
       "txled_pin": -1,
       "rxled_pin": -1,
-      "tx_power": 22,
+      "tx_power": 18,
       "use_dio3_tcxo": true,
       "preamble_length": 17
     },
@@ -77,7 +77,7 @@
       "txled_pin": -1,
       "rxled_pin": -1,
       "en_pin": 26,
-      "tx_power": 22,
+      "tx_power": 18,
       "use_dio3_tcxo": true,
       "use_dio2_rf": true,
       "preamble_length": 17


### PR DESCRIPTION
Testing shows a setting of 18 is sufficient for full output power. May help improve TX signal quality.