### PR TITLE
Change MeshMapper Observer upload URL

### DIFF
--- a/repeater/presets/meshmapper.yaml
+++ b/repeater/presets/meshmapper.yaml
@@ -21,10 +21,10 @@ website: "https://meshmapper.net"
 brokers:
   - name: "MeshMapper"
     enabled: true
-    host: mqtt.meshmapper.cc
+    host: mqtt.meshmapper.net
     port: 443
     transport: "websockets"
-    audience: "mqtt.meshmapper.cc"
+    audience: "mqtt.meshmapper.net"
     use_jwt_auth: true
     format: letsmesh
     retain_status: false

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -89,8 +89,8 @@ def test_get_preset_meshmapper_is_single_broker_mc2mqtt():
     brokers = preset.get("brokers", [])
     assert len(brokers) == 1
     broker = brokers[0]
-    assert broker["host"] == "mqtt.meshmapper.cc"
-    assert broker["audience"] == "mqtt.meshmapper.cc"
+    assert broker["host"] == "mqtt.meshmapper.net"
+    assert broker["audience"] == "mqtt.meshmapper.net"
     assert broker.get("format") == "letsmesh"
 
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -76,7 +76,7 @@ def test_get_preset_letsmesh_carries_ui_metadata():
 
 
 def test_get_preset_meshmapper_is_single_broker_mc2mqtt():
-    """MeshMapper preset is a single MC2MQTT broker on mqtt.meshmapper.cc.
+    """MeshMapper preset is a single MC2MQTT broker on mqtt.meshmapper.net.
 
     The preset intentionally re-uses the `letsmesh` format value because
     MeshMapper today speaks the standard MC2MQTT wire format with no


### PR DESCRIPTION
MeshMapper has migrated from `mqtt.meshmapper.cc` to `mqtt.meshmapper.net` 

The old Domain does not forward to the new dns.

<img width="842" height="688" alt="{6D66A806-DDD3-4C98-A585-AFDF8FCCBCD5}" src="https://github.com/user-attachments/assets/1f5df68c-b412-4119-92b8-2ecf034a597b" />

@MrAlders0n