### PR TITLE
Fix companion identity OpenAPI contract

### DIFF
--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -1862,7 +1862,7 @@ paths:
       tags: [Identities]
       summary: Create new identity
       description: |
-        Create a new repeater or room server identity.
+        Create a new companion or room server identity.
         `name` must be non-empty after trimming leading/trailing whitespace (whitespace-only values are rejected).
       requestBody:
         required: true
@@ -1883,14 +1883,14 @@ paths:
                   example: "General Chat"
                 identity_key:
                   type: string
-                  pattern: '^[0-9a-fA-F]{64}$'
-                  description: 32-byte hex key (64 chars). Omit for auto-generation
-                  example: "abc123def456..."
+                  pattern: '^(?:[0-9a-fA-F]{64}|[0-9a-fA-F]{128})$'
+                  description: 32- or 64-byte hex key (64 or 128 chars). Omit for auto-generation
+                  example: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 type:
                   type: string
-                  enum: [repeater, room_server]
+                  enum: [companion, room_server]
                   description: |
-                    - repeater: Repeater identity (only one allowed)
+                    - companion: Companion identity with a TCP endpoint
                     - room_server: Room server for group chat
                   example: room_server
                 settings:
@@ -1914,6 +1914,22 @@ paths:
                       default: 32
                       description: Maximum messages to keep (hard limit 32)
                       example: 32
+                    node_name:
+                      type: string
+                      description: Advertised node name (companion only; defaults to identity name)
+                      example: "My Companion"
+                    tcp_port:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      default: 5000
+                      description: TCP listener port (companion only)
+                      example: 5000
+                    bind_address:
+                      type: string
+                      default: "0.0.0.0"
+                      description: TCP listener bind address (companion only)
+                      example: "0.0.0.0"
             examples:
               room_server:
                 value:
@@ -1923,11 +1939,15 @@ paths:
                     admin_password: "admin123"
                     guest_password: "guest123"
                     max_posts: 32
-              repeater:
+              companion:
                 value:
-                  name: "My Repeater"
-                  type: repeater
-                  identity_key: "abc123def456..."
+                  name: "My Companion"
+                  type: companion
+                  identity_key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  settings:
+                    node_name: "My Companion"
+                    tcp_port: 5000
+                    bind_address: "0.0.0.0"
       responses:
         '200':
           description: Identity created

--- a/tests/test_openapi_identity_contract.py
+++ b/tests/test_openapi_identity_contract.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_create_identity_schema_matches_supported_identity_types():
+    spec_path = Path(__file__).parents[1] / "repeater" / "web" / "openapi.yaml"
+    spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+
+    schema = spec["paths"]["/create_identity"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    properties = schema["properties"]
+
+    assert properties["type"]["enum"] == ["companion", "room_server"]
+    assert {"node_name", "tcp_port", "bind_address"} <= set(
+        properties["settings"]["properties"]
+    )
+    assert set(
+        spec["paths"]["/create_identity"]["post"]["requestBody"]["content"][
+            "application/json"
+        ]["examples"]
+    ) == {"companion", "room_server"}

--- a/tests/test_openapi_identity_contract.py
+++ b/tests/test_openapi_identity_contract.py
@@ -13,11 +13,9 @@ def test_create_identity_schema_matches_supported_identity_types():
     properties = schema["properties"]
 
     assert properties["type"]["enum"] == ["companion", "room_server"]
-    assert {"node_name", "tcp_port", "bind_address"} <= set(
-        properties["settings"]["properties"]
-    )
+    assert {"node_name", "tcp_port", "bind_address"} <= set(properties["settings"]["properties"])
     assert set(
-        spec["paths"]["/create_identity"]["post"]["requestBody"]["content"][
-            "application/json"
-        ]["examples"]
+        spec["paths"]["/create_identity"]["post"]["requestBody"]["content"]["application/json"][
+            "examples"
+        ]
     ) == {"companion", "room_server"}


### PR DESCRIPTION
## Summary

* Correct `/create_identity` to support `companion | room_server`.
* Remove the unsupported `repeater` identity type from the OpenAPI schema.
* Document companion configuration fields: `node_name`, `tcp_port`, and `bind_address`.
* Support the backend's accepted 32-byte and 64-byte identity key formats.
* Add valid companion examples and schema regression coverage.
* Verify that TypeScript client generation now produces `"companion" | "room_server"`.

## Root Cause

The generated API integration introduced in pyMC-RepeaterUI PR [#60](https://github.com/pyMC-dev/pyMC-RepeaterUI/pull/60) relied on an outdated Repeater OpenAPI contract.

The schema advertised `repeater | room_server`, while the backend implementation accepts `companion | room_server`. As a result, generated clients inherited the incorrect validation and rejected companion creation requests before contacting the backend.

The issue originated in commit `c94b273`, which introduced the generated API client integration using the stale schema.

The resulting compiled UI was later bundled into the Repeater `dev` branch by commit `225feda`.

## Related UI Fix

The corresponding frontend fix is included in pyMC-RepeaterUI PR [#65](https://github.com/pyMC-dev/pyMC-RepeaterUI/pull/65).

## Validation

* OpenAPI route-contract validation passed.
* Schema regression assertions passed.
* Regenerated TypeScript client produces `"companion" | "room_server"` as expected.
* Companion identity examples validate successfully against the updated schema.
