### PR TITLE
Feat/database load mitigations

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -19,7 +19,16 @@ class SQLiteHandler:
         self._api_token_last_used_interval_sec = 300
         self._hot_cache_ttl_sec = 60
         self._packet_stats_cache = {}
+        self._packet_type_stats_cache = {}
         self._neighbors_cache = {"timestamp": 0.0, "value": None}
+        # Short time-based cache for the per-packet cumulative-counts aggregate
+        # (two full-table scans). The storage writer thread calls this once per
+        # recorded packet/duplicate; a few seconds of staleness is fine for the
+        # RRD/UI counters and stops a full scan running on every packet.
+        # Intentionally NOT cleared by _invalidate_hot_caches() — that runs on
+        # every write, which would defeat the cache under load.
+        self._cumulative_counts_cache = {"timestamp": 0.0, "value": None}
+        self._cumulative_counts_ttl_sec = 3.0
         # Thread-local storage for persistent SQLite connections.
         # Opening a new connection on every DB call is expensive on SD-card
         # storage: each sqlite3.connect() call triggers file-system operations
@@ -1186,7 +1195,11 @@ class SQLiteHandler:
 
     def get_packet_type_stats(self, hours: int = 24) -> dict:
         try:
-            cutoff = time.time() - (hours * 3600)
+            now = time.time()
+            cached = self._packet_type_stats_cache.get(hours)
+            if cached and (now - cached["timestamp"]) < self._hot_cache_ttl_sec:
+                return cached["value"]
+            cutoff = now - (hours * 3600)
 
             # Align with pyMC_core feat/newRadios PAYLOAD_TYPES (0x0B = CONTROL)
             try:
@@ -1262,13 +1275,15 @@ class SQLiteHandler:
                 if other_count > 0:
                     type_counts["Other Types (>15)"] = other_count
 
-                return {
+                result = {
                     "hours": hours,
                     "packet_type_totals": type_counts,
                     "total_packets": sum(type_counts.values()),
                     "period": f"{hours} hours",
                     "data_source": "sqlite",
                 }
+                self._packet_type_stats_cache[hours] = {"timestamp": now, "value": result}
+                return result
 
         except Exception as e:
             logger.error(f"Failed to get packet type stats from SQLite: {e}")
@@ -1602,6 +1617,11 @@ class SQLiteHandler:
             logger.error(f"Failed to cleanup old data: {e}")
 
     def get_cumulative_counts(self) -> dict:
+        now = time.time()
+        cached = self._cumulative_counts_cache.get("value")
+        cached_ts = float(self._cumulative_counts_cache.get("timestamp", 0.0))
+        if cached is not None and (now - cached_ts) < self._cumulative_counts_ttl_sec:
+            return cached
         try:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
@@ -1630,12 +1650,14 @@ class SQLiteHandler:
                 """
                 ).fetchone()
 
-                return {
+                result = {
                     "rx_total": int(totals["rx_total"] or 0),
                     "tx_total": int(totals["tx_total"] or 0),
                     "drop_total": int(totals["drop_total"] or 0),
                     "type_counts": type_counts,
                 }
+                self._cumulative_counts_cache = {"timestamp": now, "value": result}
+                return result
 
         except Exception as e:
             logger.error(f"Failed to get cumulative counts: {e}")

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import logging
+import threading
 import time
 from typing import Optional
 
@@ -67,8 +68,9 @@ class StorageCollector:
         # Initialize WebSocket handler for real-time updates
         self.websocket_available = False
         self.websocket_has_connected_clients = lambda: False
-        self._last_ws_stats_broadcast: float = 0.0
         self._ws_stats_broadcast_interval_sec: float = 5.0
+        self._stats_stop_event = threading.Event()
+        self._stats_thread: Optional[threading.Thread] = None
         try:
             from .websocket_handler import (
                 broadcast_packet,
@@ -81,6 +83,19 @@ class StorageCollector:
             self.websocket_has_connected_clients = has_connected_clients
             self.websocket_available = True
             logger.info("WebSocket handler initialized for real-time updates")
+
+            # Broadcast aggregate stats on a fixed cadence rather than inline on the
+            # per-packet write path. get_packet_stats(24h) is a multi-second aggregate;
+            # running it inside _record_packet_blocking made the storage writer thread
+            # spend ~1-2s of every 5s on it, competing with packet inserts. A dedicated
+            # tick keeps the writer doing only fast writes and only runs the aggregate
+            # when a dashboard client is actually connected.
+            self._stats_thread = threading.Thread(
+                target=self._stats_broadcast_loop,
+                name="stats-broadcast",
+                daemon=True,
+            )
+            self._stats_thread.start()
         except ImportError:
             logger.debug("WebSocket handler not available")
 
@@ -200,35 +215,48 @@ class StorageCollector:
         self._publish_packet_sync(packet_record, skip_mqtt)
 
     def _publish_packet_sync(self, packet_record: dict, skip_mqtt: bool):
-        """Publish packet updates synchronously (used when no asyncio loop is active)."""
+        """Publish a single packet (glass, per-packet WebSocket event, MQTT).
+
+        Only fast, per-packet work runs here. The aggregate stats broadcast is
+        driven separately by _stats_broadcast_loop so the writer thread is not
+        held by the multi-second get_packet_stats(24h) query.
+        """
         self._publish_to_glass(packet_record, "packet")
 
         if self.websocket_available:
             try:
                 self.websocket_broadcast_packet(packet_record)
-                if self.websocket_has_connected_clients():
-                    now_mono = time.monotonic()
-                    if (
-                        now_mono - self._last_ws_stats_broadcast
-                        >= self._ws_stats_broadcast_interval_sec
-                    ):
-                        self._last_ws_stats_broadcast = now_mono
-                        packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
-                        uptime_seconds = (
-                            time.time() - self.repeater_handler.start_time
-                            if self.repeater_handler
-                            else 0
-                        )
-                        self.websocket_broadcast_stats(
-                            {
-                                "packet_stats": packet_stats_24h,
-                                "system_stats": {"uptime_seconds": uptime_seconds},
-                            }
-                        )
             except Exception as e:
                 logger.debug(f"WebSocket broadcast failed: {e}")
 
         self._publish_packet_to_mqtt(packet_record)
+
+    def _broadcast_stats_once(self) -> None:
+        """Compute the 24h aggregate and broadcast it to WebSocket clients."""
+        packet_stats_24h = self.sqlite_handler.get_packet_stats(hours=24)
+        uptime_seconds = (
+            time.time() - self.repeater_handler.start_time if self.repeater_handler else 0
+        )
+        self.websocket_broadcast_stats(
+            {
+                "packet_stats": packet_stats_24h,
+                "system_stats": {"uptime_seconds": uptime_seconds},
+            }
+        )
+
+    def _stats_broadcast_loop(self) -> None:
+        """Broadcast aggregate stats every interval while clients are connected.
+
+        Runs on its own thread (off the event loop and off the storage writer) so
+        the heavy get_packet_stats(24h) aggregate never sits in the packet write
+        path. Skips the query entirely when no dashboard client is connected.
+        """
+        while not self._stats_stop_event.wait(self._ws_stats_broadcast_interval_sec):
+            try:
+                if self.websocket_has_connected_clients():
+                    self._broadcast_stats_once()
+            except Exception as e:
+                logger.debug(f"Stats broadcast failed: {e}")
 
     def _publish_packet_to_mqtt(self, packet_record: dict):
         """Publish packet to mqtt broker if enabled and allowed.
@@ -443,6 +471,11 @@ class StorageCollector:
         return self.sqlite_handler.get_noise_floor_stats(hours)
 
     def close(self):
+        # Stop the stats broadcast thread.
+        self._stats_stop_event.set()
+        if self._stats_thread is not None:
+            self._stats_thread.join(timeout=2)
+
         # Drain and stop the storage writer thread first so pending writes and
         # publishes complete before MQTT and the DB connections are torn down.
         self._db_executor.shutdown(wait=True)

--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import logging
 import time
 from typing import Optional
@@ -19,6 +20,17 @@ class StorageCollector:
         self.repeater_handler = repeater_handler
         self.glass_publish_callback = None
         self._pending_tasks = set()
+
+        # Dedicated single writer thread for all blocking storage work (the SQLite
+        # write, the cumulative-counts aggregate, RRD updates, and network
+        # publishing). This keeps that work off the asyncio event loop, which it
+        # was previously stalling for seconds per packet on a busy mesh — starving
+        # every other coroutine (e.g. send_advert would time out). One worker
+        # preserves packet write ordering and reuses a single thread-local SQLite
+        # connection (no WAL writer contention, no connection fan-out).
+        self._db_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="storage-writer"
+        )
 
         self.storage_dir = resolve_storage_dir(config)
         self.storage_dir.mkdir(parents=True, exist_ok=True)
@@ -145,7 +157,12 @@ class StorageCollector:
         return stats
 
     def record_packet(self, packet_record: dict, skip_mqtt_if_invalid: bool = True):
-        """Record packet to storage and publish to MQTT
+        """Record a packet to storage and publish it.
+
+        All blocking work — the SQLite write, the cumulative-counts aggregate, the
+        RRD update, and network publishing — runs on the dedicated writer thread so
+        it never blocks the asyncio event loop. Callers treat this as
+        fire-and-forget (the previous synchronous version blocked the loop).
 
         Args:
             packet_record: Dictionary containing packet information
@@ -155,27 +172,32 @@ class StorageCollector:
             f"Recording packet: type={packet_record.get('type')}, "
             f"transmitted={packet_record.get('transmitted')}"
         )
+        self._submit_db(self._record_packet_blocking, packet_record, skip_mqtt_if_invalid)
 
-        # HOT PATH: Store to local databases only (fast, non-blocking)
+    def _submit_db(self, fn, *args):
+        """Run a blocking storage operation on the dedicated writer thread.
+
+        Falls back to running inline only if the executor has already been shut
+        down (process teardown), so late records are not silently dropped.
+        """
+        try:
+            self._db_executor.submit(self._run_db_task, fn, *args)
+        except RuntimeError:
+            self._run_db_task(fn, *args)
+
+    def _run_db_task(self, fn, *args):
+        """Execute a writer-thread task, logging (not raising) on failure."""
+        try:
+            fn(*args)
+        except Exception as e:
+            logger.error(f"Storage writer task failed: {e}", exc_info=True)
+
+    def _record_packet_blocking(self, packet_record: dict, skip_mqtt: bool):
+        """Store, aggregate, update metrics, and publish one packet (writer thread)."""
         self.sqlite_handler.store_packet(packet_record)
         cumulative_counts = self.sqlite_handler.get_cumulative_counts()
         self.rrd_handler.update_packet_metrics(packet_record, cumulative_counts)
-
-        # DEFERRED: Publish to network sinks and WebSocket in background tasks
-        # This prevents network latency from blocking packet processing
-        self._schedule_background(
-            self._deferred_publish,
-            packet_record,
-            skip_mqtt_if_invalid,
-            sync_fallback=self._publish_packet_sync,
-        )
-
-    async def _deferred_publish(self, packet_record: dict, skip_mqtt: bool):
-        """Deferred background task for all network publishing operations."""
-        try:
-            self._publish_packet_sync(packet_record, skip_mqtt)
-        except Exception as e:
-            logger.error(f"Deferred publish failed: {e}", exc_info=True)
+        self._publish_packet_sync(packet_record, skip_mqtt)
 
     def _publish_packet_sync(self, packet_record: dict, skip_mqtt: bool):
         """Publish packet updates synchronously (used when no asyncio loop is active)."""
@@ -421,6 +443,10 @@ class StorageCollector:
         return self.sqlite_handler.get_noise_floor_stats(hours)
 
     def close(self):
+        # Drain and stop the storage writer thread first so pending writes and
+        # publishes complete before MQTT and the DB connections are torn down.
+        self._db_executor.shutdown(wait=True)
+
         # Cancel all pending background tasks
         for task in self._pending_tasks:
             if not task.done():

--- a/tests/test_storage_collector_ws_stats_throttle.py
+++ b/tests/test_storage_collector_ws_stats_throttle.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -30,6 +31,14 @@ def _make_collector() -> StorageCollector:
     ):
         collector = StorageCollector(config={"storage": {"storage_dir": "/tmp/pymc_repeater_test"}})
 
+    # Stop any real stats-broadcast thread started during construction so the tests
+    # drive the loop deterministically.
+    collector._stats_stop_event.set()
+    if collector._stats_thread is not None:
+        collector._stats_thread.join(timeout=1)
+    collector._stats_stop_event = threading.Event()
+    collector._stats_thread = None
+
     collector.sqlite_handler = MagicMock()
     collector.sqlite_handler.get_packet_stats.return_value = {"total_packets": 1}
     collector.websocket_available = True
@@ -40,40 +49,50 @@ def _make_collector() -> StorageCollector:
     return collector
 
 
-def test_publish_packet_sync_first_call_broadcasts_stats_immediately():
+def test_publish_packet_sync_broadcasts_packet_event_not_stats():
+    # The per-packet path must stay fast: it broadcasts the packet event but never
+    # runs the heavy aggregate or the stats broadcast (those moved to the loop).
     collector = _make_collector()
 
-    with patch("repeater.data_acquisition.storage_collector.time.monotonic", return_value=1000.0):
-        collector._publish_packet_sync({"type": 1, "transmitted": True}, skip_mqtt=False)
+    collector._publish_packet_sync({"type": 1, "transmitted": True}, skip_mqtt=False)
 
-    assert collector.sqlite_handler.get_packet_stats.call_count == 1
-    assert collector.websocket_broadcast_stats.call_count == 1
     assert collector.websocket_broadcast_packet.call_count == 1
-
-
-def test_publish_packet_sync_throttles_stats_to_interval():
-    collector = _make_collector()
-    call_times = [1000.0 + (i * 0.1) for i in range(10)] + [1005.1]
-
-    with patch(
-        "repeater.data_acquisition.storage_collector.time.monotonic",
-        side_effect=call_times,
-    ):
-        for _ in call_times:
-            collector._publish_packet_sync({"type": 1, "transmitted": True}, skip_mqtt=False)
-
-    assert collector.sqlite_handler.get_packet_stats.call_count == 2
-    assert collector.websocket_broadcast_stats.call_count == 2
-    assert collector.websocket_broadcast_packet.call_count == len(call_times)
-
-
-def test_publish_packet_sync_always_broadcasts_packet_event_even_without_clients():
-    collector = _make_collector()
-    collector.websocket_has_connected_clients.return_value = False
-
-    for _ in range(5):
-        collector._publish_packet_sync({"type": 1, "transmitted": True}, skip_mqtt=False)
-
-    assert collector.websocket_broadcast_packet.call_count == 5
     assert collector.sqlite_handler.get_packet_stats.call_count == 0
     assert collector.websocket_broadcast_stats.call_count == 0
+
+
+def test_broadcast_stats_once_queries_and_broadcasts():
+    collector = _make_collector()
+
+    collector._broadcast_stats_once()
+
+    collector.sqlite_handler.get_packet_stats.assert_called_once_with(hours=24)
+    assert collector.websocket_broadcast_stats.call_count == 1
+    payload = collector.websocket_broadcast_stats.call_args.args[0]
+    assert payload["packet_stats"] == {"total_packets": 1}
+    assert "uptime_seconds" in payload["system_stats"]
+
+
+def test_stats_loop_broadcasts_when_clients_connected():
+    collector = _make_collector()
+    collector._broadcast_stats_once = MagicMock()
+    collector.websocket_has_connected_clients = MagicMock(return_value=True)
+    # Drive exactly one iteration: wait() returns False (proceed) then True (exit).
+    collector._stats_stop_event = MagicMock()
+    collector._stats_stop_event.wait.side_effect = [False, True]
+
+    collector._stats_broadcast_loop()
+
+    assert collector._broadcast_stats_once.call_count == 1
+
+
+def test_stats_loop_skips_when_no_clients():
+    collector = _make_collector()
+    collector._broadcast_stats_once = MagicMock()
+    collector.websocket_has_connected_clients = MagicMock(return_value=False)
+    collector._stats_stop_event = MagicMock()
+    collector._stats_stop_event.wait.side_effect = [False, True]
+
+    collector._stats_broadcast_loop()
+
+    assert collector._broadcast_stats_once.call_count == 0


### PR DESCRIPTION
Sending an advert from the web UI timed out (10s) on busy repeaters. A live py-spy dump caught the asyncio loop thread running synchronous SQLite (`get_cumulative_counts`, `get_packet_stats`) per packet — stalling the loop for seconds so `run_coroutine_threadsafe(send_advert)` never got scheduled. Not a firmware/modem issue; the advert was just the visible victim.

### Changes
- **Move per-packet storage off the loop.** `record_packet` now submits the SQLite write + cumulative-counts + RRD update + publish to a dedicated single `storage-writer` thread (preserves ordering, reuses one thread-local conn).
- **Cache the hot aggregates.** `get_cumulative_counts` (3s TTL) so the per-packet scan doesn't re-run every packet; `get_packet_type_stats` (60s) to cut dashboard DB contention.
- **Decouple the WS stats broadcast.** The multi-second `get_packet_stats(24h)` moves from the per-packet path to its own 5s `stats-broadcast` thread (skipped when no client is connected), keeping the writer thread on fast inserts only.

### Verification
- py-spy: loop thread idle in `select`; SQLite only on `storage-writer` / `stats-broadcast`; advert sends fast; dashboards still update.
- `pytest tests/test_storage_collector_ws_stats_throttle.py tests/test_sqlite_handler_easy.py` — 12 passed.