### PR TITLE
feat(presets): add Meshat.se broker preset

### DIFF
--- a/repeater/presets/meshat-se.yaml
+++ b/repeater/presets/meshat-se.yaml
@@ -1,0 +1,28 @@
+# Meshat.se MC2MQTT broker preset.
+#
+# Meshat.se is a Swedish community MeshCore visualization and analytics
+# platform. Their single ingest broker speaks the standard MeshCoreToMQTT
+# (MC2MQTT) protocol with the LetsMesh-compatible topic structure
+# (meshcore/{IATA}/{PUBLIC_KEY}/...).
+#
+# Reference all Meshat.se endpoints with: brokers: [{preset: meshat-se}]
+#
+# Optional UI metadata. Consumed by the GET /api/broker_presets endpoint
+# so the React/Vue admin can render this preset in the "From Template"
+# dropdown. `display_name` and `website` are advisory only -- they are
+# never read by the runtime broker connection code.
+display_name: "Meshat.se"
+website: "https://meshat.se"
+brokers:
+  - name: "Meshat.se"
+    enabled: true
+    host: meshcore-mqtt.meshat.se
+    port: 443
+    transport: "websockets"
+    audience: "meshcore-mqtt.meshat.se"
+    use_jwt_auth: true
+    format: letsmesh
+    retain_status: false
+    tls:
+      enabled: true
+      insecure: false

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -30,6 +30,7 @@ def test_list_presets_returns_bundled_names():
     assert "waev" in names
     assert "letsmesh" in names
     assert "meshmapper" in names
+    assert "meshat-se" in names
 
 
 def test_get_preset_waev_uses_alias_for_server_side_failover():


### PR DESCRIPTION
Adds a built-in broker preset for Meshat.se
(https://meshat.se), a swedish community MQTT broker.

The preset uses WebSockets to meshcore-mqtt.meshat.se:443
with LetsMesh topic format and JWT auth.