### PR TITLE
Fix: Pass jwt_expiry_minutes from config to MQTT handler

### DIFF
--- a/repeater/data_acquisition/storage_collector.py
+++ b/repeater/data_acquisition/storage_collector.py
@@ -45,10 +45,14 @@ class StorageCollector:
             config.get("mqtt_brokers", {}) or config.get("letsmesh", {}) or config.get("mqtt", {})
         ) and local_identity:
             try:
+                # Extract JWT expiry from repeater.security config (default 10 minutes for backward compatibility)
+                jwt_expiry_minutes = config.get("repeater", {}).get("security", {}).get("jwt_expiry_minutes", 10)
+
                 # Pass local_identity directly (supports both standard and firmware keys)
                 self.mqtt_handler = MeshCoreToMqttPusher(
                     local_identity=local_identity,
                     config=config,
+                    jwt_expiry_minutes=jwt_expiry_minutes,
                     stats_provider=self._get_live_stats,
                 )
                 self.mqtt_handler.connect()


### PR DESCRIPTION
I am not sure this is the best way to fix this, but here is one way i figured out. Seems the current setup it ignored the config value of 60 min

The MQTT handler was always using the hardcoded default of 10 minutes instead of reading the configured value. This caused reconnections every 8 minutes regardless of the config setting.

Now extracts jwt_expiry_minutes from repeater.security config and passes it to MeshCoreToMqttPusher, allowing the user's configuration to be honored.

Fixes issue where mqtt_brokers with jwt_expiry_minutes: 60 still reconnected every ~8 min.