### PR TITLE
Bundle Console UI into Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.image_repository }}" ]; then
             image_repository="${{ inputs.image_repository }}"
           elif [ "${{ github.repository_owner }}" = "yellowcooln" ]; then
-            image_repository="yellowcooln/openhop-repeater"
+            image_repository="yellowcooln/pymc-repeater"
           else
             image_repository="openhop/openhop-repeater"
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,14 +10,14 @@ on:
       image_repository:
         description: "Docker image repository to publish to"
         required: false
-        default: "openhop/openhop-repeater"
+        default: ""
 
 jobs:
   docker:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.repository == 'openhop-dev/openhop_repeater' ||
-      github.repository == 'yellowcooln/openhop_repeater'
+      github.repository_owner == 'yellowcooln'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,7 +58,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.image_repository }}" ]; then
             image_repository="${{ inputs.image_repository }}"
-          elif [ "${{ github.repository }}" = "yellowcooln/openhop_repeater" ]; then
+          elif [ "${{ github.repository_owner }}" = "yellowcooln" ]; then
             image_repository="yellowcooln/openhop-repeater"
           else
             image_repository="openhop/openhop-repeater"

--- a/README.md
+++ b/README.md
@@ -428,6 +428,15 @@ that source as a directory, which breaks startup.
 docker compose up -d
 ```
 
+The Docker image bundles the optional PyMC Console frontend at
+`/opt/pymc_console/web/html`. Local builds with `docker-compose.build.yml`
+download the newest PyMC Console release by default. Set `PYMC_CONSOLE_VERSION`
+in `.env` to pin a release tag such as `v0.9.329`.
+
+After the container starts, open Web Settings and choose `PyMC Console` as the
+web frontend if you want the repeater to serve that UI. The existing
+`/api/check_pymc_console` endpoint should report that the Console path exists.
+
 ### Example `docker-compose.yml`
 
 ```yaml

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -10,3 +10,4 @@ services:
         DIALOUT_GID: ${DIALOUT_GID:-20}
         GPIO_GID: ${GPIO_GID:-986}
         SPI_GID: ${SPI_GID:-989}
+        PYMC_CONSOLE_VERSION: ${PYMC_CONSOLE_VERSION:-latest}

--- a/dockerfile
+++ b/dockerfile
@@ -10,10 +10,13 @@ ARG GPIO_GID=986
 ARG SPI_GID=989
 ARG TARGETARCH
 ARG YQ_VERSION=v4.40.5
+ARG PYMC_CONSOLE_REPO=Treehouse-00/pymc_console-dist
+ARG PYMC_CONSOLE_VERSION=latest
 
 ENV INSTALL_DIR=/opt/openhop_repeater \
     CONFIG_DIR=/etc/openhop_repeater \
     DATA_DIR=/var/lib/openhop_repeater \
+    PYMC_CONSOLE_WEB_DIR=/opt/pymc_console/web/html \
     HOME_DIR=/home/${USER} \
     PATH=/home/${USER}/.local/bin:${PATH} \
     PYTHONUNBUFFERED=1 \
@@ -49,6 +52,21 @@ RUN arch="${TARGETARCH:-}" \
     && wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}" \
     && chmod +x /usr/local/bin/yq
 
+# Bundle the optional PyMC Console frontend so the web UI can select it without
+# requiring a host bind mount. Use PYMC_CONSOLE_VERSION=latest to pull the
+# newest release at image build time, or pin a tag such as v0.9.329.
+RUN set -eux; \
+    mkdir -p "${PYMC_CONSOLE_WEB_DIR}"; \
+    if [ "${PYMC_CONSOLE_VERSION}" = "latest" ]; then \
+        console_url="https://github.com/${PYMC_CONSOLE_REPO}/releases/latest/download/pymc-ui-latest.tar.gz"; \
+    else \
+        console_url="https://github.com/${PYMC_CONSOLE_REPO}/releases/download/${PYMC_CONSOLE_VERSION}/pymc-ui-${PYMC_CONSOLE_VERSION}.tar.gz"; \
+    fi; \
+    wget -qO /tmp/pymc-console.tar.gz "${console_url}"; \
+    tar -xzf /tmp/pymc-console.tar.gz -C "${PYMC_CONSOLE_WEB_DIR}"; \
+    rm /tmp/pymc-console.tar.gz; \
+    test -f "${PYMC_CONSOLE_WEB_DIR}/index.html"
+
 # Create the group and user in order to run without root privileges
 RUN groupadd --gid "$PGID" "$GROUP" \
     && (getent group dialout >/dev/null || groupadd --gid "$DIALOUT_GID" dialout) \
@@ -59,7 +77,7 @@ RUN groupadd --gid "$PGID" "$GROUP" \
 
 # Create runtime directories
 RUN mkdir -p ${INSTALL_DIR} ${CONFIG_DIR} ${DATA_DIR} \
-    && chown -R "$USER":"$GROUP" ${INSTALL_DIR} ${CONFIG_DIR} ${DATA_DIR} ${HOME_DIR}
+    && chown -R "$USER":"$GROUP" ${INSTALL_DIR} ${CONFIG_DIR} ${DATA_DIR} ${HOME_DIR} /opt/pymc_console
 
 WORKDIR ${INSTALL_DIR}
 

--- a/env.example
+++ b/env.example
@@ -29,3 +29,9 @@ SPI_GID=989
 # image yourself instead of pulling OPENHOP_REPEATER_IMAGE.
 PUID=15888
 PGID=15888
+
+# Local build only. The Docker image bundles PyMC Console under
+# /opt/pymc_console/web/html so it is available in Web Settings without a host
+# bind mount. Use "latest" to pull the newest pyMC Console release at build
+# time, or pin a tag such as v0.9.329.
+PYMC_CONSOLE_VERSION=latest


### PR DESCRIPTION
This PR adds [Console](https://github.com/Treehouse-00/pymc_console-dist) to the docker image.

This allows users using docker or the HA Add-on the option of using Console without modification.

HA users wouldn't have a easy way to add Console UI without this. 