### PR TITLE
feat: Allow setting max. flood interval to 168

### DIFF
--- a/repeater/handler_helpers/mesh_cli.py
+++ b/repeater/handler_helpers/mesh_cli.py
@@ -212,7 +212,7 @@ class MeshCLI:
                 "  set guest.password <pw> Guest password\n"
                 "  set allow.read.only on|off  Read-only access\n"
                 "  set advert.interval <min>   60-240 minutes\n"
-                "  set flood.advert.interval <hr>  3-50 hours\n"
+                "  set flood.advert.interval <hr>  3-168 hours\n"
                 "  set flood.max <hops>   Max flood hops (max 64)\n"
                 "  set rxdelay <val>      RX delay base (>=0)\n"
                 "  set txdelay <val>      TX delay factor (>=0)\n"
@@ -541,8 +541,8 @@ class MeshCLI:
 
             elif key == "flood.advert.interval":
                 hours = int(value)
-                if (hours > 0 and hours < 3) or hours > 50:
-                    return "Error: interval range is 3-50 hours"
+                if (hours > 0 and hours < 3) or hours > 168:
+                    return "Error: interval range is 3-168 hours"
                 self.repeater_config["flood_advert_interval_hours"] = hours
                 saved, _ = self.config_manager.save_to_file()
                 self.config_manager.live_update_daemon(["repeater"])

--- a/repeater/handler_helpers/mesh_cli.py
+++ b/repeater/handler_helpers/mesh_cli.py
@@ -212,7 +212,7 @@ class MeshCLI:
                 "  set guest.password <pw> Guest password\n"
                 "  set allow.read.only on|off  Read-only access\n"
                 "  set advert.interval <min>   60-240 minutes\n"
-                "  set flood.advert.interval <hr>  3-48 hours\n"
+                "  set flood.advert.interval <hr>  3-50 hours\n"
                 "  set flood.max <hops>   Max flood hops (max 64)\n"
                 "  set rxdelay <val>      RX delay base (>=0)\n"
                 "  set txdelay <val>      TX delay factor (>=0)\n"
@@ -541,8 +541,8 @@ class MeshCLI:
 
             elif key == "flood.advert.interval":
                 hours = int(value)
-                if (hours > 0 and hours < 3) or hours > 48:
-                    return "Error: interval range is 3-48 hours"
+                if (hours > 0 and hours < 3) or hours > 50:
+                    return "Error: interval range is 3-50 hours"
                 self.repeater_config["flood_advert_interval_hours"] = hours
                 saved, _ = self.config_manager.save_to_file()
                 self.config_manager.live_update_daemon(["repeater"])

--- a/repeater/handler_helpers/repeater_cli.py
+++ b/repeater/handler_helpers/repeater_cli.py
@@ -231,7 +231,7 @@ class MeshCLI:
                 "  set guest.password <pw> Guest password\n"
                 "  set allow.read.only on|off  Read-only access\n"
                 "  set advert.interval <min>   60-240 minutes\n"
-                "  set flood.advert.interval <hr>  3-50 hours\n"
+                "  set flood.advert.interval <hr>  3-168 hours\n"
                 "  set flood.max <hops>   Max flood hops (max 64)\n"
                 "  set rxdelay <val>      RX delay base (>=0)\n"
                 "  set txdelay <val>      TX delay factor (>=0)\n"
@@ -519,8 +519,8 @@ class MeshCLI:
 
             elif key == "flood.advert.interval":
                 hours = int(value)
-                if (hours > 0 and hours < 3) or hours > 50:
-                    return "Error: interval range is 3-50 hours"
+                if (hours > 0 and hours < 3) or hours > 168:
+                    return "Error: interval range is 3-168 hours"
                 self.repeater_config["flood_advert_interval_hours"] = hours
                 self.save_config()
                 return "OK"

--- a/repeater/handler_helpers/repeater_cli.py
+++ b/repeater/handler_helpers/repeater_cli.py
@@ -231,7 +231,7 @@ class MeshCLI:
                 "  set guest.password <pw> Guest password\n"
                 "  set allow.read.only on|off  Read-only access\n"
                 "  set advert.interval <min>   60-240 minutes\n"
-                "  set flood.advert.interval <hr>  3-48 hours\n"
+                "  set flood.advert.interval <hr>  3-50 hours\n"
                 "  set flood.max <hops>   Max flood hops (max 64)\n"
                 "  set rxdelay <val>      RX delay base (>=0)\n"
                 "  set txdelay <val>      TX delay factor (>=0)\n"
@@ -519,8 +519,8 @@ class MeshCLI:
 
             elif key == "flood.advert.interval":
                 hours = int(value)
-                if (hours > 0 and hours < 3) or hours > 48:
-                    return "Error: interval range is 3-48 hours"
+                if (hours > 0 and hours < 3) or hours > 50:
+                    return "Error: interval range is 3-50 hours"
                 self.repeater_config["flood_advert_interval_hours"] = hours
                 self.save_config()
                 return "OK"

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -3326,7 +3326,7 @@ class APIEndpoints:
             "latitude": 0.0,             # Latitude (-90 to 90)
             "longitude": 0.0,            # Longitude (-180 to 180)
             "max_flood_hops": 64,         # Max flood hops (0-64)
-            "flood_advert_interval_hours": 10,  # Flood advert interval (0 or 3-50)
+            "flood_advert_interval_hours": 10,  # Flood advert interval (0 or 3-168)
             "advert_interval_minutes": 120      # Local advert interval (0 or 1-10080)
         }
 
@@ -3461,8 +3461,8 @@ class APIEndpoints:
             # Update flood advert interval (hours)
             if "flood_advert_interval_hours" in data:
                 hours = int(data["flood_advert_interval_hours"])
-                if hours != 0 and (hours < 3 or hours > 50):
-                    return self._error("Flood advert interval must be 0 (off) or 3-50 hours")
+                if hours != 0 and (hours < 3 or hours > 168):
+                    return self._error("Flood advert interval must be 0 (off) or 3-168 hours")
                 self.config["repeater"]["send_advert_interval_hours"] = hours
                 applied.append(f"flood.advert.interval={hours}h")
 

--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -3326,7 +3326,7 @@ class APIEndpoints:
             "latitude": 0.0,             # Latitude (-90 to 90)
             "longitude": 0.0,            # Longitude (-180 to 180)
             "max_flood_hops": 64,         # Max flood hops (0-64)
-            "flood_advert_interval_hours": 10,  # Flood advert interval (0 or 3-48)
+            "flood_advert_interval_hours": 10,  # Flood advert interval (0 or 3-50)
             "advert_interval_minutes": 120      # Local advert interval (0 or 1-10080)
         }
 
@@ -3461,8 +3461,8 @@ class APIEndpoints:
             # Update flood advert interval (hours)
             if "flood_advert_interval_hours" in data:
                 hours = int(data["flood_advert_interval_hours"])
-                if hours != 0 and (hours < 3 or hours > 48):
-                    return self._error("Flood advert interval must be 0 (off) or 3-48 hours")
+                if hours != 0 and (hours < 3 or hours > 50):
+                    return self._error("Flood advert interval must be 0 (off) or 3-50 hours")
                 self.config["repeater"]["send_advert_interval_hours"] = hours
                 applied.append(f"flood.advert.interval={hours}h")
 

--- a/tests/test_identity_manager_and_repeater_cli.py
+++ b/tests/test_identity_manager_and_repeater_cli.py
@@ -203,7 +203,7 @@ def test_cli_set_commands_apply_and_validate_ranges():
     assert cli._cmd_set("advert.interval 60") == "OK"
 
     assert cli._cmd_set("flood.advert.interval 2").startswith("Error: interval range")
-    assert cli._cmd_set("flood.advert.interval 50") == "OK"
+    assert cli._cmd_set("flood.advert.interval 168") == "OK"
 
     assert cli._cmd_set("flood.max 65") == "Error: max 64"
     assert cli._cmd_set("flood.max 64") == "OK"

--- a/tests/test_identity_manager_and_repeater_cli.py
+++ b/tests/test_identity_manager_and_repeater_cli.py
@@ -203,7 +203,7 @@ def test_cli_set_commands_apply_and_validate_ranges():
     assert cli._cmd_set("advert.interval 60") == "OK"
 
     assert cli._cmd_set("flood.advert.interval 2").startswith("Error: interval range")
-    assert cli._cmd_set("flood.advert.interval 48") == "OK"
+    assert cli._cmd_set("flood.advert.interval 50") == "OK"
 
     assert cli._cmd_set("flood.max 65") == "Error: max 64"
     assert cli._cmd_set("flood.max 64") == "OK"


### PR DESCRIPTION
We're moving the flood interval in The Netherlands to 50, OpenHop didn't allow for higher than 48 so I bumped it to 168 hours to match the Meshcore CLI: https://docs.meshcore.io/cli_commands/#view-or-change-the-flood-advert-interval.

Originally bumped to 50, hence the branch name, was suggested I match the CLI, so since updated.