### PR TITLE
fix: update dependencies for platform-specific installation of openhop-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,9 @@ pre-commit run --all-files
 ```
 
 Hardware support for LoRa radio drivers is included in the base installation
-through `openhop_core[hardware]`.
+through `openhop_core[hardware]` on Linux. On other platforms (e.g. macOS),
+`openhop_core` is installed without the hardware extra, since `spidev` and
+similar packages only build against the Linux SPI kernel headers.
 
 Pre-commit hooks will automatically:
 - Lint and auto-fix Python issues with Ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ keywords = ["mesh", "networking", "lora", "repeater", "daemon", "iot"]
 
 
 dependencies = [
-    "openhop_core[hardware]",
+    "openhop_core[hardware] ; sys_platform == 'linux'",
+    "openhop_core ; sys_platform != 'linux'",
     "pyyaml>=6.0.0",
     "cherrypy>=18.0.0",
     "paho-mqtt>=1.6.0",


### PR DESCRIPTION
## Summary

`pip install -e ".[dev]"` fails on macOS because `openhop_core[hardware]` unconditionally pulls in `spidev`, which requires the Linux SPI kernel header (`linux/spi/spidev.h`) to build. This header doesn't exist on macOS, so the wheel build fails and blocks contributors from setting up a dev environment on non-Linux machines.

## Changes

*pyproject.toml:* Split the `openhop_core` dependency by `sys_platform` marker so the `hardware` extra (and therefore `spidev`) is only requested on Linux. Non-Linux platforms get plain `openhop_core`.
*README.md:* Documented the platform-conditional behavior in the Development Setup section.

## Testing

Verified in a clean virtualenv on macOS that `pip install -e ".[dev]"` now completes successfully, installing `openhop_core` without `spidev`. Linux installs are unaffected since the `hardware` extra is still requested there via the `sys_platform == 'linux'` marker.