### PR TITLE
perf: add covering index for airtime chart queries

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -973,10 +973,16 @@ class SQLiteHandler:
                     (cutoff,),
                 ).fetchone()
 
+                # INDEXED BY forces the timestamp range scan. Without it the
+                # planner picks idx_packets_type / idx_packets_transmitted to get
+                # grouping for free, then heap-checks the timestamp filter across
+                # the entire table — turning a bounded window into a full scan
+                # (~5s vs ~0.1s at 1.5M rows). A small temp b-tree over the
+                # windowed rows is far cheaper.
                 types = conn.execute(
                     """
                     SELECT type, COUNT(*) as count
-                    FROM packets
+                    FROM packets INDEXED BY idx_packets_timestamp
                     WHERE timestamp > ?
                     GROUP BY type
                     ORDER BY count DESC
@@ -987,7 +993,7 @@ class SQLiteHandler:
                 drop_reasons = conn.execute(
                     """
                     SELECT drop_reason, COUNT(*) as count
-                    FROM packets
+                    FROM packets INDEXED BY idx_packets_timestamp
                     WHERE timestamp > ? AND transmitted = 0 AND drop_reason IS NOT NULL
                     GROUP BY drop_reason
                     ORDER BY count DESC
@@ -1314,10 +1320,12 @@ class SQLiteHandler:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
 
+                # See get_packet_stats: force the timestamp range scan so the
+                # windowed GROUP BY doesn't degrade into a full-table scan.
                 type_rows = conn.execute(
                     """
                     SELECT type, COUNT(*) as count
-                    FROM packets
+                    FROM packets INDEXED BY idx_packets_timestamp
                     WHERE timestamp > ?
                     GROUP BY type
                 """,

--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -191,6 +191,14 @@ class SQLiteHandler:
                 conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_packets_transmitted ON packets(transmitted)"
                 )
+                # Covering index for the airtime/utilization charts. get_airtime_data
+                # and get_airtime_buckets range-scan and order by timestamp, selecting
+                # only these columns; keeping them all in the index lets SQLite serve
+                # the query index-only, avoiding a full scan of the (large) row heap.
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_packets_airtime "
+                    "ON packets(timestamp, length, payload_length, transmitted)"
+                )
                 conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_adverts_timestamp ON adverts(timestamp)"
                 )


### PR DESCRIPTION
The airtime/utilization chart queries (get_airtime_data and get_airtime_buckets) range-scan and order packets by timestamp, selecting only timestamp/length/payload_length/transmitted. On a large packets table this forced a full scan of the row heap, saturating slow storage (e.g. a Pi SD card): each dashboard poll took longer than the client timeout, aborted polls stacked, and sustained I/O starved the transmit queue.

Add a covering index on packets(timestamp, length, payload_length, transmitted) so these queries run index-only, dropping the read from the full row heap to just the index range. Verified via EXPLAIN QUERY PLAN (COVERING INDEX idx_packets_airtime). Additive and idempotent.