### PR TITLE
fix: enable DIO3 TCXO and DIO2 RF switch for MeshAdv Mini preset

### DIFF
--- a/radio-settings.json
+++ b/radio-settings.json
@@ -95,6 +95,8 @@
       "txled_pin": -1,
       "rxled_pin": -1,
       "tx_power": 22,
+      "use_dio3_tcxo": true,
+      "use_dio2_rf": true,
       "preamble_length": 32
     },
     "meshadv": {


### PR DESCRIPTION
The E22-900M22S module on the MeshAdv Mini requires DIO3-powered TCXO and DIO2-controlled RF switching, per the vendor's official config. Without these flags the radio fails with TX timeouts (IRQ 0x0000) or transmits no usable RF despite appearing healthy.

Matches the existing meshadv and zebra preset pattern.