### PR TITLE
feat(mqtt): enable neighbors configuration in meshat-se preset

### DIFF
--- a/repeater/presets/meshat-se.yaml
+++ b/repeater/presets/meshat-se.yaml
@@ -23,6 +23,7 @@ brokers:
     use_jwt_auth: true
     format: letsmesh
     retain_status: false
+    neighbors: true
     tls:
       enabled: true
       insecure: false


### PR DESCRIPTION
Added a new `neighbors: true` setting to the `meshat-se.yaml` configuration file under the MQTT brokers section, allowing for neighbor discovery functionality to be enabled in this preset.