### PR TITLE
feat(api): dedicated update_radio_hardware_config endpoint

### DIFF
--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -34,6 +34,14 @@ from .auth.middleware import require_auth
 from .auth_endpoints import AuthAPIEndpoints
 from .cad_calibration_engine import CADCalibrationEngine
 from .companion_endpoints import CompanionAPIEndpoints
+from .hardware_presets import (
+    SECTION_BY_RADIO_TYPE,
+    SUPPORTED_RADIO_TYPES,
+    apply_hardware_preset,
+    load_hardware_presets,
+    sections_allowed_for,
+    validate_section,
+)
 from .update_endpoints import UpdateAPIEndpoints
 
 logger = logging.getLogger("HTTPServer")
@@ -1332,30 +1340,17 @@ class APIEndpoints:
     def hardware_options(self):
         """Get available hardware configurations from radio-settings.json"""
         try:
-            import json
-
-            # Check config-based location first, then development location
-            config_dir = resolve_storage_dir(self.config, config_path=self._config_path)
-            installed_path = config_dir / "radio-settings.json"
-            dev_path = os.path.join(os.path.dirname(__file__), "..", "..", "radio-settings.json")
-
-            hardware_file = str(installed_path) if installed_path.exists() else dev_path
-            hardware_list = []
-
-            if os.path.exists(hardware_file):
-                with open(hardware_file, "r") as f:
-                    hardware_data = json.load(f)
-                hardware_configs = hardware_data.get("hardware", {})
-                for hw_key, hw_config in hardware_configs.items():
-                    if isinstance(hw_config, dict):
-                        hardware_list.append(
-                            {
-                                "key": hw_key,
-                                "name": hw_config.get("name", hw_key),
-                                "description": hw_config.get("description", ""),
-                                "config": hw_config,
-                            }
-                        )
+            hardware_list = [
+                {
+                    "key": hw_key,
+                    "name": hw_config.get("name", hw_key),
+                    "description": hw_config.get("description", ""),
+                    "config": hw_config,
+                }
+                for hw_key, hw_config in load_hardware_presets(
+                    self.config, self._config_path
+                ).items()
+            ]
 
             return {"hardware": hardware_list}
         except Exception as e:
@@ -1394,6 +1389,158 @@ class APIEndpoints:
         except Exception as e:
             logger.error(f"Error loading radio presets: {e}")
             return {"error": str(e)}
+
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    @cherrypy.tools.json_in()
+    def update_radio_hardware_config(self):
+        """Change the radio hardware backend.
+
+        Dedicated endpoint for the Configuration → Radio Hardware tab.
+        Auth is inherited from the /api mount (require_auth tool);
+        /api/config_import stays dedicated to first-run bootstrap restore.
+
+        POST /api/update_radio_hardware_config
+
+        Preset mode — the preset is applied backend-side from
+        radio-settings.json, including fields the UI has no widgets for
+        (use_dio3_tcxo, use_dio2_rf, gpio backend, ...), then the
+        overrides merge on top section-by-section:
+            {"hardware_key": "bq-station-g3",
+             "overrides": {"sx1262": {"irq_pin": 23}}}
+        The sx1262/ch341 sections are REPLACED by the preset+overrides
+        result: they are shared across SPI boards, so stale pins from a
+        previous board must not linger. Serial/network modem sections
+        (kiss/pymc_usb/pymc_tcp) belong to exactly one backend and may
+        hold operator keys with no preset equivalent (pymc_tcp.token,
+        lbt_enabled, ...) — those are MERGED. The radio section is
+        merged too (frequency/SF/BW belong to the Radio Settings tab),
+        though a preset that defines tx_power/preamble_length DOES
+        overwrite those two values on every preset save.
+
+        Manual mode — explicit sections for custom builds; only the
+        section owned by radio_type is accepted (plus ch341 for
+        sx1262_ch341) and it is MERGED into the existing section, so
+        preset-managed fields without form widgets survive pin tweaks.
+        radio_type null/"none" disables the radio:
+            {"radio_type": "pymc_usb",
+             "pymc_usb": {"port": "/dev/ttyACM0", "baudrate": 921600}}
+
+        Returns: {"success": true, "restart_required": true,
+                  "applied": [...]}
+        """
+        self._set_cors_headers()
+        if cherrypy.request.method == "OPTIONS":
+            return ""
+        try:
+            self._require_post()
+            data = cherrypy.request.json or {}
+
+            applied = []
+            hardware_key = str(data.get("hardware_key") or "").strip()
+
+            if hardware_key:
+                # ── Preset mode ─────────────────────────────────
+                presets = load_hardware_presets(self.config, self._config_path)
+                hw_config = presets.get(hardware_key)
+                if not hw_config:
+                    return self._error(f"Unknown hardware preset: {hardware_key}")
+
+                # Stage preset + overrides on a scratch dict so nothing is
+                # committed when a later override fails validation.
+                staged = {}
+                apply_hardware_preset(staged, hw_config)
+                radio_type = staged.get("radio_type") or "sx1262"
+
+                overrides = data.get("overrides") or {}
+                if not isinstance(overrides, dict):
+                    return self._error("'overrides' must be an object")
+                allowed = sections_allowed_for(radio_type)
+                for section, fields in overrides.items():
+                    if section not in allowed:
+                        return self._error(
+                            f"Section '{section}' is not valid for "
+                            f"radio_type '{radio_type}'"
+                        )
+                    sanitized = validate_section(section, fields)
+                    staged.setdefault(section, {}).update(sanitized)
+
+                self.config["radio_type"] = radio_type
+                applied.append(f"radio_type={radio_type}")
+                applied.append(f"preset={hardware_key}")
+                for section, fields in staged.items():
+                    if section == "radio_type":
+                        continue
+                    if section in ("sx1262", "ch341"):
+                        # Replace: shared across SPI boards — stale pins
+                        # from a previous board must not linger.
+                        self.config[section] = dict(fields)
+                    else:
+                        # Merge: 'radio' keeps frequency/SF/BW, and the
+                        # kiss/pymc_* sections keep operator keys that
+                        # have no preset equivalent (token, lbt_*, ...).
+                        self.config.setdefault(section, {}).update(fields)
+                    applied.extend(f"{section}.{key}" for key in fields)
+            else:
+                # ── Manual mode ─────────────────────────────────
+                if "radio_type" not in data:
+                    return self._error("Missing 'hardware_key' or 'radio_type'")
+                radio_type_raw = data.get("radio_type")
+                if radio_type_raw in (None, "", "none"):
+                    self.config["radio_type"] = None
+                    applied.append("radio_type=none")
+                else:
+                    radio_type = str(radio_type_raw).strip().lower()
+                    if radio_type not in SUPPORTED_RADIO_TYPES:
+                        return self._error(
+                            f"Unsupported radio_type '{radio_type_raw}'. Supported: "
+                            f"{', '.join(SUPPORTED_RADIO_TYPES)}, none"
+                        )
+                    allowed = sections_allowed_for(radio_type)
+                    unexpected = [
+                        section
+                        for section in SECTION_BY_RADIO_TYPE.values()
+                        if section in data and section not in allowed
+                    ]
+                    if "ch341" in data and "ch341" not in allowed:
+                        unexpected.append("ch341")
+                    if unexpected:
+                        return self._error(
+                            f"Section(s) {', '.join(sorted(set(unexpected)))} not "
+                            f"valid for radio_type '{radio_type}'"
+                        )
+                    # Stage: validate every section BEFORE mutating
+                    # self.config, so a failed validation cannot leave the
+                    # in-memory config (served by /api/stats) diverged from
+                    # the persisted file.
+                    staged_sections = {}
+                    for section in sorted(allowed):
+                        if section not in data:
+                            continue
+                        staged_sections[section] = validate_section(section, data[section])
+                    self.config["radio_type"] = radio_type
+                    applied.append(f"radio_type={radio_type}")
+                    for section, sanitized in staged_sections.items():
+                        self.config.setdefault(section, {}).update(sanitized)
+                        applied.extend(f"{section}.{key}" for key in sanitized)
+
+            saved = self.config_manager.save_to_file()
+            if not saved:
+                return self._error("Failed to save configuration to file")
+
+            logger.info(f"Radio hardware config updated: {', '.join(applied)}")
+            return {
+                "success": True,
+                "restart_required": True,
+                "applied": applied,
+            }
+        except ValueError as e:
+            return self._error(str(e))
+        except cherrypy.HTTPError:
+            raise
+        except Exception as e:
+            logger.exception("Error updating radio hardware config")
+            return self._error(str(e))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
@@ -1612,74 +1759,14 @@ class APIEndpoints:
                 if "preamble_length" in hw_config:
                     config_yaml["radio"]["preamble_length"] = hw_config.get("preamble_length", 32)
             else:
-                # SX1262 / sx1262_ch341: radio_type and optional CH341 from hw_config
-                if "radio_type" in hw_config:
-                    config_yaml["radio_type"] = hw_config.get("radio_type")
-                else:
-                    config_yaml["radio_type"] = "sx1262"
-
-                ch341_cfg = (
-                    hw_config.get("ch341") if isinstance(hw_config.get("ch341"), dict) else None
+                # SX1262 / sx1262_ch341: apply the preset via the shared
+                # helper — radio_type, ch341 vid/pid, radio.tx_power /
+                # preamble_length, and every known sx1262-section field.
+                # (Same helper as /api/update_radio_hardware_config, so a
+                # new preset field only needs support in one place.)
+                apply_hardware_preset(
+                    config_yaml, hw_config, tx_power_override=tx_power_preset
                 )
-                vid = (ch341_cfg or {}).get("vid", hw_config.get("vid"))
-                pid = (ch341_cfg or {}).get("pid", hw_config.get("pid"))
-                if vid is not None or pid is not None:
-                    if "ch341" not in config_yaml:
-                        config_yaml["ch341"] = {}
-                    if vid is not None:
-                        config_yaml["ch341"]["vid"] = vid
-                    if pid is not None:
-                        config_yaml["ch341"]["pid"] = pid
-
-                if tx_power_preset is not None:
-                    config_yaml["radio"]["tx_power"] = tx_power_preset
-                elif "tx_power" in hw_config:
-                    config_yaml["radio"]["tx_power"] = hw_config.get("tx_power", 22)
-                if "preamble_length" in hw_config:
-                    config_yaml["radio"]["preamble_length"] = hw_config.get("preamble_length", 32)
-
-                if "sx1262" not in config_yaml:
-                    config_yaml["sx1262"] = {}
-                if "bus_id" in hw_config:
-                    config_yaml["sx1262"]["bus_id"] = hw_config.get("bus_id", 0)
-                if "cs_id" in hw_config:
-                    config_yaml["sx1262"]["cs_id"] = hw_config.get("cs_id", 0)
-                if "reset_pin" in hw_config:
-                    config_yaml["sx1262"]["reset_pin"] = hw_config.get("reset_pin", 22)
-                if "busy_pin" in hw_config:
-                    config_yaml["sx1262"]["busy_pin"] = hw_config.get("busy_pin", 17)
-                if "irq_pin" in hw_config:
-                    config_yaml["sx1262"]["irq_pin"] = hw_config.get("irq_pin", 16)
-                if "txen_pin" in hw_config:
-                    config_yaml["sx1262"]["txen_pin"] = hw_config.get("txen_pin", -1)
-                if "rxen_pin" in hw_config:
-                    config_yaml["sx1262"]["rxen_pin"] = hw_config.get("rxen_pin", -1)
-                if "en_pin" in hw_config:
-                    config_yaml["sx1262"]["en_pin"] = hw_config.get("en_pin", -1)
-                if "en_pins" in hw_config:
-                    config_yaml["sx1262"]["en_pins"] = hw_config.get("en_pins", [])
-                if "cs_pin" in hw_config:
-                    config_yaml["sx1262"]["cs_pin"] = hw_config.get("cs_pin", -1)
-                if "txled_pin" in hw_config:
-                    config_yaml["sx1262"]["txled_pin"] = hw_config.get("txled_pin", -1)
-                if "rxled_pin" in hw_config:
-                    config_yaml["sx1262"]["rxled_pin"] = hw_config.get("rxled_pin", -1)
-                if "use_dio3_tcxo" in hw_config:
-                    config_yaml["sx1262"]["use_dio3_tcxo"] = hw_config.get("use_dio3_tcxo", False)
-                if "dio3_tcxo_voltage" in hw_config:
-                    config_yaml["sx1262"]["dio3_tcxo_voltage"] = hw_config.get(
-                        "dio3_tcxo_voltage", 1.8
-                    )
-                if "use_dio2_rf" in hw_config:
-                    config_yaml["sx1262"]["use_dio2_rf"] = hw_config.get("use_dio2_rf", False)
-                if "is_waveshare" in hw_config:
-                    config_yaml["sx1262"]["is_waveshare"] = hw_config.get("is_waveshare", False)
-                if "gpio_chip" in hw_config:
-                    config_yaml["sx1262"]["gpio_chip"] = hw_config.get("gpio_chip", 0)
-                if "use_gpiod_backend" in hw_config:
-                    config_yaml["sx1262"]["use_gpiod_backend"] = hw_config.get(
-                        "use_gpiod_backend", False
-                    )
             # Write updated config
             with open(self._config_path, "w") as f:
                 yaml.dump(config_yaml, f, default_flow_style=False, sort_keys=False)

--- a/repeater/web/hardware_presets.py
+++ b/repeater/web/hardware_presets.py
@@ -1,0 +1,260 @@
+"""Shared helpers for radio hardware presets (radio-settings.json).
+
+Used by the first-run setup wizard and the authenticated
+/api/update_radio_hardware_config endpoint so that preset fields are
+mapped into the config in exactly one place. When a preset gains a new
+field, only apply_hardware_preset() (plus the radio driver that consumes
+the field) needs to learn it — the web UI applies presets by key and
+never has to enumerate their fields.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from ..config import resolve_storage_dir
+
+logger = logging.getLogger("HTTPServer")
+
+
+def resolve_hardware_settings_path(config: dict, config_path: str | None) -> str:
+    """Return the radio-settings.json path: installed copy first, then repo."""
+    config_dir = resolve_storage_dir(config, config_path=config_path)
+    installed_path = Path(config_dir) / "radio-settings.json"
+    dev_path = os.path.join(os.path.dirname(__file__), "..", "..", "radio-settings.json")
+    return str(installed_path) if installed_path.exists() else dev_path
+
+
+def load_hardware_presets(config: dict, config_path: str | None) -> dict[str, dict]:
+    """Load the hardware preset table from radio-settings.json.
+
+    Returns {} when the file is missing (matching the historical
+    hardware_options behavior). A file that exists but cannot be read or
+    parsed raises OSError/ValueError instead of being swallowed: callers
+    surface the error, so a corrupted file is distinguishable from an
+    empty preset list. Non-dict entries are dropped so callers can trust
+    the value shapes.
+    """
+    path = resolve_hardware_settings_path(config, config_path)
+    if not os.path.exists(path):
+        logger.debug(f"Hardware settings file not found: {path}")
+        return {}
+    with open(path, "r") as f:
+        data = json.load(f)
+    hardware = data.get("hardware", {})
+    if not isinstance(hardware, dict):
+        return {}
+    return {key: cfg for key, cfg in hardware.items() if isinstance(cfg, dict)}
+
+
+# sx1262-section fields copied verbatim from a preset when present.
+_SX1262_PRESET_FIELDS = (
+    "bus_id",
+    "cs_id",
+    "reset_pin",
+    "busy_pin",
+    "irq_pin",
+    "txen_pin",
+    "rxen_pin",
+    "en_pin",
+    "en_pins",
+    "cs_pin",
+    "txled_pin",
+    "rxled_pin",
+    "use_dio3_tcxo",
+    "dio3_tcxo_voltage",
+    "use_dio2_rf",
+    "is_waveshare",
+    "gpio_chip",
+    "use_gpiod_backend",
+)
+
+
+def apply_hardware_preset(
+    config_yaml: dict,
+    hw_config: dict,
+    tx_power_override: int | None = None,
+) -> None:
+    """Apply a radio-settings.json hardware preset onto a config dict.
+
+    Mutates config_yaml in place:
+      * radio_type from the preset (defaults to "sx1262" — SPI presets
+        historically omit the key);
+      * ch341.vid/pid when the preset carries them;
+      * radio.tx_power (tx_power_override wins when provided) and
+        radio.preamble_length;
+      * every known sx1262-section field present in the preset,
+        including the ones the web UI has no widgets for
+        (use_dio3_tcxo, use_dio2_rf, gpio backend, ...).
+
+    Serial/network modem presets (pymc_usb / pymc_tcp / kiss) carry only
+    radio_type + radio-section hints, so the sx1262 loop is a no-op for
+    them; their port/host settings come from the caller (wizard request
+    fields or endpoint overrides).
+    """
+    if "radio" not in config_yaml:
+        config_yaml["radio"] = {}
+
+    if "radio_type" in hw_config:
+        config_yaml["radio_type"] = hw_config.get("radio_type")
+    else:
+        config_yaml["radio_type"] = "sx1262"
+
+    ch341_cfg = hw_config.get("ch341") if isinstance(hw_config.get("ch341"), dict) else None
+    vid = (ch341_cfg or {}).get("vid", hw_config.get("vid"))
+    pid = (ch341_cfg or {}).get("pid", hw_config.get("pid"))
+    if vid is not None or pid is not None:
+        if "ch341" not in config_yaml:
+            config_yaml["ch341"] = {}
+        if vid is not None:
+            config_yaml["ch341"]["vid"] = vid
+        if pid is not None:
+            config_yaml["ch341"]["pid"] = pid
+
+    if tx_power_override is not None:
+        config_yaml["radio"]["tx_power"] = tx_power_override
+    elif "tx_power" in hw_config:
+        config_yaml["radio"]["tx_power"] = hw_config.get("tx_power", 22)
+    if "preamble_length" in hw_config:
+        config_yaml["radio"]["preamble_length"] = hw_config.get("preamble_length", 32)
+
+    if any(field in hw_config for field in _SX1262_PRESET_FIELDS):
+        if "sx1262" not in config_yaml:
+            config_yaml["sx1262"] = {}
+        for field in _SX1262_PRESET_FIELDS:
+            if field in hw_config:
+                config_yaml["sx1262"][field] = hw_config.get(field)
+
+
+# ─── Validation for /api/update_radio_hardware_config ───────────────
+
+SUPPORTED_RADIO_TYPES = ("sx1262", "sx1262_ch341", "kiss", "pymc_usb", "pymc_tcp")
+
+# Config section owned by each radio_type (what the endpoint may write).
+SECTION_BY_RADIO_TYPE = {
+    "kiss": "kiss",
+    "pymc_usb": "pymc_usb",
+    "pymc_tcp": "pymc_tcp",
+    "sx1262": "sx1262",
+    "sx1262_ch341": "sx1262",
+}
+
+
+def _require_int(section: str, field: str, value: Any, lo: int, hi: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{section}.{field} must be an integer")
+    if number < lo or number > hi:
+        raise ValueError(f"{section}.{field} must be between {lo} and {hi}")
+    return number
+
+
+def _validate_kiss(fields: dict) -> dict:
+    out = {}
+    if "port" in fields:
+        port = str(fields["port"]).strip()
+        if not port:
+            raise ValueError("kiss.port must not be empty")
+        out["port"] = port
+    if "baud_rate" in fields:
+        out["baud_rate"] = _require_int("kiss", "baud_rate", fields["baud_rate"], 1200, 4_000_000)
+    return out
+
+
+def _validate_pymc_usb(fields: dict) -> dict:
+    out = {}
+    if "port" in fields:
+        port = str(fields["port"]).strip()
+        if not port:
+            raise ValueError("pymc_usb.port must not be empty")
+        out["port"] = port
+    if "baudrate" in fields:
+        out["baudrate"] = _require_int("pymc_usb", "baudrate", fields["baudrate"], 1200, 4_000_000)
+    return out
+
+
+def _validate_pymc_tcp(fields: dict) -> dict:
+    out = {}
+    if "host" in fields:
+        host = str(fields["host"]).strip()
+        if not host:
+            raise ValueError("pymc_tcp.host must not be empty")
+        out["host"] = host
+    if "port" in fields:
+        out["port"] = _require_int("pymc_tcp", "port", fields["port"], 1, 65535)
+    if "token" in fields:
+        out["token"] = str(fields["token"])
+    return out
+
+
+_SX1262_ID_FIELDS = ("bus_id", "cs_id")
+_SX1262_PIN_FIELDS = (
+    "cs_pin",
+    "reset_pin",
+    "busy_pin",
+    "irq_pin",
+    "txen_pin",
+    "rxen_pin",
+    "en_pin",
+    "txled_pin",
+    "rxled_pin",
+)
+
+
+def _validate_sx1262(fields: dict) -> dict:
+    out = {}
+    for field in _SX1262_ID_FIELDS:
+        if field in fields:
+            out[field] = _require_int("sx1262", field, fields[field], 0, 15)
+    for field in _SX1262_PIN_FIELDS:
+        if field in fields:
+            out[field] = _require_int("sx1262", field, fields[field], -1, 255)
+    if "en_pins" in fields:
+        pins = fields["en_pins"]
+        if not isinstance(pins, list):
+            raise ValueError("sx1262.en_pins must be a list of integers")
+        out["en_pins"] = [_require_int("sx1262", "en_pins", pin, 0, 255) for pin in pins]
+    return out
+
+
+def _validate_ch341(fields: dict) -> dict:
+    out = {}
+    for field in ("vid", "pid"):
+        if field in fields:
+            out[field] = _require_int("ch341", field, fields[field], 0, 65535)
+    return out
+
+
+SECTION_VALIDATORS = {
+    "kiss": _validate_kiss,
+    "pymc_usb": _validate_pymc_usb,
+    "pymc_tcp": _validate_pymc_tcp,
+    "sx1262": _validate_sx1262,
+    "ch341": _validate_ch341,
+}
+
+
+def sections_allowed_for(radio_type: str) -> set:
+    """Sections the endpoint may accept for a given radio_type."""
+    allowed = {SECTION_BY_RADIO_TYPE[radio_type]}
+    if radio_type == "sx1262_ch341":
+        allowed.add("ch341")
+    return allowed
+
+
+def validate_section(section: str, fields: Any) -> dict:
+    """Validate one section payload; raises ValueError with a user-facing
+    message, returns the sanitized field dict."""
+    if not isinstance(fields, dict):
+        # ValueError on purpose (not TypeError): the endpoint maps
+        # ValueError to a user-facing 200 {"success": false, "error": ...}.
+        raise ValueError(f"'{section}' must be an object")  # noqa: TRY004
+    validator = SECTION_VALIDATORS.get(section)
+    if validator is None:
+        raise ValueError(f"Unsupported section '{section}'")
+    return validator(fields)

--- a/repeater/web/openapi.yaml
+++ b/repeater/web/openapi.yaml
@@ -855,6 +855,66 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
 
+  /update_radio_hardware_config:
+    post:
+      tags: [System]
+      summary: Change the radio hardware backend
+      description: >
+        Dedicated save endpoint for the Configuration → Radio Hardware tab.
+        Preset mode ({"hardware_key": "...", "overrides": {...}}) applies the
+        radio-settings.json preset backend-side — including fields the UI has
+        no widgets for — then merges the overrides on top. The sx1262/ch341
+        sections are replaced by the preset+overrides result (stale pins from
+        a previous board must not linger); other sections are merged, so
+        operator keys without a preset equivalent (pymc_tcp.token, lbt_*)
+        survive. A preset that defines tx_power/preamble_length overwrites
+        those two radio values on every preset save. Manual mode
+        ({"radio_type": "...", "<section>": {...}}) accepts only the section
+        owned by the radio_type; radio_type null/"none" disables the radio.
+        Changes require a service restart to take effect.
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              # Manual mode carries the section owned by radio_type at the
+              # top level (kiss / pymc_usb / pymc_tcp / sx1262 / ch341).
+              additionalProperties: true
+              properties:
+                hardware_key:
+                  type: string
+                  description: Preset key from radio-settings.json
+                overrides:
+                  type: object
+                  description: Per-section field overrides (preset mode)
+                radio_type:
+                  type: string
+                  nullable: true
+                  enum: [sx1262, sx1262_ch341, kiss, pymc_usb, pymc_tcp, none]
+                  description: Radio backend (manual mode)
+      responses:
+        '200':
+          description: Radio hardware config updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  restart_required:
+                    type: boolean
+                  applied:
+                    type: array
+                    items:
+                      type: string
+                  error:
+                    type: string
+
   # ============================================================================
   # Packet Endpoints
   # ============================================================================

--- a/tests/test_api_endpoints_core_coverage.py
+++ b/tests/test_api_endpoints_core_coverage.py
@@ -434,7 +434,10 @@ def test_hardware_options_loads_installed_file(tmp_path):
         encoding="utf-8",
     )
 
-    with patch("repeater.web.api_endpoints.resolve_storage_dir", return_value=Path(tmp_path)):
+    # Preset loading moved to repeater.web.hardware_presets — patch it there.
+    with patch(
+        "repeater.web.hardware_presets.resolve_storage_dir", return_value=Path(tmp_path)
+    ):
         result = api.hardware_options()
 
     assert len(result["hardware"]) == 1

--- a/tests/test_radio_hardware_endpoint.py
+++ b/tests/test_radio_hardware_endpoint.py
@@ -1,0 +1,321 @@
+"""Tests for /api/update_radio_hardware_config and the shared hardware
+preset helper (repeater/web/hardware_presets.py).
+
+The endpoint is the dedicated save path for the Configuration → Radio
+Hardware tab. Presets are applied backend-side from radio-settings.json
+(including fields the UI has no widgets for, e.g. use_dio3_tcxo), then
+the request overrides merge on top — see apply_hardware_preset().
+"""
+
+import json
+
+import cherrypy
+import pytest
+import yaml
+
+from repeater.web.api_endpoints import APIEndpoints
+from repeater.web.hardware_presets import apply_hardware_preset, load_hardware_presets
+
+# Preset with "hidden" fields (no UI widgets): TCXO, DIO2 RF switch.
+_STATION_G3 = {
+    "name": "BQ Voyage Station G3",
+    "bus_id": 0,
+    "cs_id": 0,
+    "cs_pin": -1,
+    "reset_pin": 16,
+    "busy_pin": 24,
+    "irq_pin": 22,
+    "txen_pin": -1,
+    "rxen_pin": -1,
+    "txled_pin": -1,
+    "rxled_pin": -1,
+    "tx_power": 19,
+    "use_dio2_rf": True,
+    "use_dio3_tcxo": True,
+    "dio3_tcxo_voltage": 1.8,
+    "preamble_length": 32,
+}
+
+_PYMC_USB_PRESET = {
+    "name": "pymc_usb modem (USB-CDC)",
+    "radio_type": "pymc_usb",
+    "tx_power": 22,
+    "preamble_length": 16,
+}
+
+_BASE_CONFIG = {
+    "repeater": {"node_name": "unit-test", "security": {"admin_password": "admin123"}},
+    "radio": {"frequency": 869618000, "spreading_factor": 8, "tx_power": 9},
+    "radio_type": "pymc_usb",
+    # lbt_enabled=False is a deliberate operator choice with no preset
+    # equivalent — preset-mode saves must not wipe it (merge, not replace).
+    "pymc_usb": {"port": "/dev/ttyACM0", "baudrate": 921600, "lbt_enabled": False},
+    # Stale keys from a previous SPI board — a preset save must not keep them.
+    "sx1262": {"irq_pin": 4, "use_gpiod_backend": True},
+}
+
+
+@pytest.fixture
+def endpoint_env(tmp_path):
+    """Tempdir with config.yaml + radio-settings.json + mocked cherrypy."""
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.safe_dump(_BASE_CONFIG, f)
+
+    with open(tmp_path / "radio-settings.json", "w") as f:
+        json.dump({"hardware": {"bq-station-g3": _STATION_G3, "pymc_usb": _PYMC_USB_PRESET}}, f)
+
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    config["storage_dir"] = str(tmp_path)
+    endpoints = APIEndpoints(config=config, config_path=str(config_path))
+
+    def _post(body):
+        cherrypy.request.method = "POST"
+        cherrypy.request.json = body
+        return endpoints.update_radio_hardware_config()
+
+    return config, config_path, _post
+
+
+def _read_yaml(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# ─── apply_hardware_preset (helper) ──────────────────────────────────
+
+
+def test_apply_preset_maps_all_fields_including_hidden_ones():
+    cfg = {}
+    apply_hardware_preset(cfg, _STATION_G3)
+
+    assert cfg["radio_type"] == "sx1262"  # SPI presets omit radio_type
+    sx = cfg["sx1262"]
+    assert sx["reset_pin"] == 16
+    assert sx["busy_pin"] == 24
+    assert sx["irq_pin"] == 22
+    assert sx["cs_pin"] == -1
+    # The fields the web form has no widgets for must be applied too.
+    assert sx["use_dio2_rf"] is True
+    assert sx["use_dio3_tcxo"] is True
+    assert sx["dio3_tcxo_voltage"] == 1.8
+    assert cfg["radio"]["tx_power"] == 19
+    assert cfg["radio"]["preamble_length"] == 32
+    # name/description are preset metadata, not config.
+    assert "name" not in sx
+
+
+def test_apply_preset_tx_power_override_wins():
+    cfg = {}
+    apply_hardware_preset(cfg, _STATION_G3, tx_power_override=14)
+    assert cfg["radio"]["tx_power"] == 14
+
+
+def test_apply_preset_ch341_vid_pid():
+    cfg = {}
+    apply_hardware_preset(
+        cfg, {"radio_type": "sx1262_ch341", "vid": 6790, "pid": 21778, "cs_pin": 0}
+    )
+    assert cfg["radio_type"] == "sx1262_ch341"
+    assert cfg["ch341"] == {"vid": 6790, "pid": 21778}
+    assert cfg["sx1262"]["cs_pin"] == 0
+
+
+# ─── endpoint: preset mode ───────────────────────────────────────────
+
+
+def test_preset_mode_applies_full_preset(endpoint_env):
+    _config, config_path, post = endpoint_env
+
+    result = post({"hardware_key": "bq-station-g3"})
+
+    assert result["success"] is True
+    assert result["restart_required"] is True
+
+    written = _read_yaml(config_path)
+    assert written["radio_type"] == "sx1262"
+    assert written["sx1262"]["reset_pin"] == 16
+    assert written["sx1262"]["use_dio3_tcxo"] is True
+    assert written["sx1262"]["use_dio2_rf"] is True
+    # Section replaced: stale keys from the previous board are gone.
+    assert "use_gpiod_backend" not in written["sx1262"]
+    # Radio section merged, not replaced: tuning params survive.
+    assert written["radio"]["frequency"] == 869618000
+    assert written["radio"]["spreading_factor"] == 8
+    assert written["radio"]["tx_power"] == 19  # from preset
+    assert written["radio"]["preamble_length"] == 32
+
+
+def test_preset_mode_overrides_merge_on_top(endpoint_env):
+    _config, config_path, post = endpoint_env
+
+    result = post({"hardware_key": "bq-station-g3", "overrides": {"sx1262": {"irq_pin": 23}}})
+
+    assert result["success"] is True
+    written = _read_yaml(config_path)
+    assert written["sx1262"]["irq_pin"] == 23  # override
+    assert written["sx1262"]["reset_pin"] == 16  # preset intact
+    assert written["sx1262"]["use_dio3_tcxo"] is True  # hidden field intact
+
+
+def test_preset_mode_unknown_key(endpoint_env):
+    _config, config_path, post = endpoint_env
+    before = _read_yaml(config_path)
+
+    result = post({"hardware_key": "does-not-exist"})
+
+    assert result["success"] is False
+    assert "does-not-exist" in result["error"]
+    assert _read_yaml(config_path) == before  # nothing written
+
+
+def test_preset_mode_rejects_foreign_override_section(endpoint_env):
+    _config, config_path, post = endpoint_env
+    before = _read_yaml(config_path)
+
+    result = post({"hardware_key": "bq-station-g3", "overrides": {"pymc_usb": {"port": "/dev/x"}}})
+
+    assert result["success"] is False
+    assert "pymc_usb" in result["error"]
+    assert _read_yaml(config_path) == before
+
+
+def test_preset_mode_invalid_override_commits_nothing(endpoint_env):
+    config, config_path, post = endpoint_env
+    before = _read_yaml(config_path)
+
+    result = post({"hardware_key": "bq-station-g3", "overrides": {"sx1262": {"irq_pin": "abc"}}})
+
+    assert result["success"] is False
+    assert "irq_pin" in result["error"]
+    assert _read_yaml(config_path) == before
+    # In-memory config untouched too (staged application).
+    assert config["radio_type"] == "pymc_usb"
+
+
+def test_preset_mode_non_spi_preset_with_port_override(endpoint_env):
+    _config, config_path, post = endpoint_env
+
+    result = post(
+        {
+            "hardware_key": "pymc_usb",
+            "overrides": {"pymc_usb": {"port": "/dev/ttyACM1", "baudrate": 115200}},
+        }
+    )
+
+    assert result["success"] is True
+    written = _read_yaml(config_path)
+    assert written["radio_type"] == "pymc_usb"
+    assert written["pymc_usb"]["port"] == "/dev/ttyACM1"
+    assert written["pymc_usb"]["baudrate"] == 115200
+    assert written["radio"]["preamble_length"] == 16  # from preset
+
+
+def test_preset_mode_non_spi_merge_preserves_operator_keys(endpoint_env):
+    """kiss/pymc_* sections are merged (not replaced) in preset mode:
+    operator keys with no preset equivalent must survive."""
+    _config, config_path, post = endpoint_env
+
+    result = post({"hardware_key": "pymc_usb", "overrides": {"pymc_usb": {"port": "/dev/ttyACM1"}}})
+
+    assert result["success"] is True
+    written = _read_yaml(config_path)
+    assert written["pymc_usb"]["port"] == "/dev/ttyACM1"  # override applied
+    assert written["pymc_usb"]["baudrate"] == 921600  # untouched key kept
+    assert written["pymc_usb"]["lbt_enabled"] is False  # operator key kept
+
+
+def test_load_hardware_presets_corrupt_file_raises(tmp_path):
+    """A corrupted radio-settings.json must raise (surfaced as an error by
+    hardware_options), not read as an empty preset list."""
+    (tmp_path / "radio-settings.json").write_text("{not json", encoding="utf-8")
+    config = {"storage_dir": str(tmp_path)}
+
+    with pytest.raises(ValueError):
+        load_hardware_presets(config, str(tmp_path / "config.yaml"))
+
+
+# ─── endpoint: manual mode ───────────────────────────────────────────
+
+
+def test_manual_mode_pymc_usb(endpoint_env):
+    _config, config_path, post = endpoint_env
+
+    result = post(
+        {"radio_type": "pymc_usb", "pymc_usb": {"port": "/dev/ttyUSB2", "baudrate": 460800}}
+    )
+
+    assert result["success"] is True
+    written = _read_yaml(config_path)
+    assert written["radio_type"] == "pymc_usb"
+    assert written["pymc_usb"]["port"] == "/dev/ttyUSB2"
+    assert written["pymc_usb"]["baudrate"] == 460800
+
+
+def test_manual_mode_sx1262_merges_section(endpoint_env):
+    """Manual pin tweaks must not wipe preset-managed fields that have no
+    form widgets (TCXO & co survive a custom pin edit)."""
+    _config, config_path, post = endpoint_env
+
+    # First apply the preset (writes use_dio3_tcxo etc.)
+    post({"hardware_key": "bq-station-g3"})
+    # Then a manual save with just pins.
+    result = post({"radio_type": "sx1262", "sx1262": {"irq_pin": 25}})
+
+    assert result["success"] is True
+    written = _read_yaml(config_path)
+    assert written["sx1262"]["irq_pin"] == 25
+    assert written["sx1262"]["use_dio3_tcxo"] is True  # survived the merge
+
+
+def test_manual_mode_none_disables_radio(endpoint_env):
+    _config, config_path, post = endpoint_env
+
+    result = post({"radio_type": None})
+
+    assert result["success"] is True
+    written = _read_yaml(config_path)
+    assert written["radio_type"] is None
+
+
+def test_manual_mode_unsupported_radio_type(endpoint_env):
+    _config, _config_path, post = endpoint_env
+
+    result = post({"radio_type": "flux_capacitor"})
+
+    assert result["success"] is False
+    assert "flux_capacitor" in result["error"]
+
+
+def test_manual_mode_rejects_foreign_section(endpoint_env):
+    _config, _config_path, post = endpoint_env
+
+    result = post({"radio_type": "pymc_usb", "sx1262": {"irq_pin": 22}})
+
+    assert result["success"] is False
+    assert "sx1262" in result["error"]
+
+
+def test_manual_mode_validates_field_ranges(endpoint_env):
+    config, config_path, post = endpoint_env
+    before = _read_yaml(config_path)
+
+    result = post({"radio_type": "pymc_tcp", "pymc_tcp": {"host": "modem.local", "port": 99999}})
+
+    assert result["success"] is False
+    assert "port" in result["error"]
+    assert _read_yaml(config_path) == before
+    # Manual mode is staged too: the in-memory config (served by
+    # /api/stats) must not diverge from the file on validation failure.
+    assert config["radio_type"] == "pymc_usb"
+    assert "pymc_tcp" not in config
+
+
+def test_missing_key_and_type(endpoint_env):
+    _config, _config_path, post = endpoint_env
+
+    result = post({})
+
+    assert result["success"] is False
+    assert "hardware_key" in result["error"]


### PR DESCRIPTION
## Problem

The Configuration → Radio Hardware tab saves through `/api/config_import`. That endpoint is auth-exempt (`tools.require_auth.on: False` in `http_server.py`) so first-run restore can work before an account exists — but the auth tool is the only thing that populates `cherrypy.request.user`, so on that route the user is **never** authenticated, even with a valid JWT. Once setup is complete, `config_import`'s own guard returns **403 "Unauthorized restore"** for every save from the tab, which the SPA surfaces as *"Unknown error occurred"*.

Reproduction against a configured node:

```
$ curl -s -X POST -H "Content-Type: application/json" \
    -H "Authorization: Bearer <valid-or-not, ignored>" \
    -d '{"config":{}}' http://<node>:8000/api/config_import
HTTP 403 {"error": "Unauthorized restore. First-run setup is already complete; ..."}
```

Two more defects ride along the same path:
- the tab only sends the form's visible pin fields, silently dropping preset fields that have no widgets (`use_dio3_tcxo`, `use_dio2_rf`, `gpio_chip`, `use_gpiod_backend`, ...) — e.g. a Station G3 configured from the tab would lose its TCXO settings;
- `config_import` merges raw dicts with no validation.

## Change

New `POST /api/update_radio_hardware_config`, guarded by the normal `/api` auth tool (no exemption). `/api/config_import` keeps its bootstrap-restore role untouched.

- **Preset mode** `{"hardware_key": "...", "overrides": {...}}` — the radio-settings.json preset is applied backend-side, then overrides merge on top. The `sx1262`/`ch341` sections are **replaced** by the preset+overrides result (they are shared across SPI boards; stale pins from a previous board must not linger). Other sections are **merged**: `radio` keeps frequency/SF/BW, and the `kiss`/`pymc_*` sections keep operator keys that have no preset equivalent (`pymc_tcp.token`, `lbt_enabled`, ...).
- **Manual mode** `{"radio_type": "...", "<section>": {...}}` — validated field-by-field; only the section owned by the `radio_type` is accepted and it is merged, so preset-managed fields survive pin tweaks. `radio_type` null/`"none"` disables the radio.
- **Both modes stage validation before mutating the live config** — a failed request cannot leave the in-memory config (served by `/api/stats`) diverged from the persisted file.
- The preset→config mapping moves out of `setup_wizard` into `repeater/web/hardware_presets.py` (`apply_hardware_preset`), shared by the wizard and the new endpoint: a preset gaining a new field needs support in exactly one place, and the UI never has to enumerate preset fields. `hardware_options` loads presets through the same helper; a corrupted `radio-settings.json` still surfaces as an error there (only a missing file reads as an empty preset list).
- Endpoint declared in `openapi.yaml` (with `additionalProperties: true` for the manual-mode sections) so the SPA client can be generated from it.

## Design notes / deliberate behavior

- **A preset that defines `tx_power`/`preamble_length` overwrites those two `radio` values on every preset save** — adopting the new board's safe TX power is the point when switching hardware, but re-saving the same preset also resets manual tuning. The UI shows both values in a read-only block with an explicit warning. Flagging for review in case a different trade-off is preferred.
- Preset-mode `sx1262` replace intentionally drops hand-added keys the preset doesn't define (e.g. a custom `gpio_chip`); manual mode merges and preserves them.

## Companion PR

openHop_RepeaterUI: switches the tab to this endpoint and adds the read-only "Preset-managed settings" block: openhop-dev/openHop_RepeaterUI#92. The prebuilt assets under `repeater/web/html/` are intentionally not touched here.

## Test plan

- [x] `pytest tests/test_radio_hardware_endpoint.py` — 18 tests: full-preset application (hidden fields included), override merge, replace-vs-merge semantics (incl. operator-key preservation on `pymc_*`), staged validation in both modes (file **and** in-memory config unchanged on error), manual-mode validation, corrupt-presets-file error propagation, unknown preset/type/section rejection
- [x] `pytest tests/test_setup_wizard_pymc.py tests/test_api_endpoints_setup.py tests/test_api_endpoints_core_coverage.py tests/test_config_manager.py` — 118 passed total (wizard refactor covered by existing tests)
- [x] `ruff check` / `ruff format --check` clean on new files; zero new findings on `api_endpoints.py`
