### PR TITLE
docs: point Repeater guidance to central site

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ integrations.
 
 ## Contents
 
-- [Overview](#overview)
-- [Screenshots](#screenshots)
-- [Supported Hardware](#supported-hardware)
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Policy Engine](#policy-engine)
-- [Upgrading](#upgrading)
-- [Proxmox LXC Installation](#proxmox-lxc-installation)
-- [Uninstallation](#uninstallation)
-- [Docker Compose](#docker-compose)
+- [Overview](https://docs.openhop.dev/projects/openhop-repeater/what-is-openhop-repeater/)
+- [Screenshots and dashboard](https://docs.openhop.dev/projects/openhop-repeater/web-dashboard/)
+- [Supported Hardware](https://docs.openhop.dev/projects/openhop-repeater/hardware-setup/)
+- [Installation](https://docs.openhop.dev/projects/openhop-repeater/installation/)
+- [Configuration](https://docs.openhop.dev/projects/openhop-repeater/config-file/)
+- [Policy Engine](https://docs.openhop.dev/projects/openhop-repeater/web-dashboard/)
+- [Upgrading](https://docs.openhop.dev/projects/openhop-repeater/installation/#upgrading-an-older-pymc-installation)
+- [Proxmox LXC Installation](https://docs.openhop.dev/projects/openhop-repeater/installation/#proxmox-lxc-with-ch341)
+- [Uninstallation](https://docs.openhop.dev/projects/openhop-repeater/uninstallation/)
+- [Docker Compose](https://docs.openhop.dev/projects/openhop-repeater/docker/)
 - [Roadmap](#roadmap)
-- [Contributing](#contributing)
+- [Contributing](https://docs.openhop.dev/projects/openhop-repeater/development/)
 - [Support](#support)
 - [Disclaimer](#disclaimer)
 - [License](#license)
@@ -381,18 +381,19 @@ The installer also enables `use_dio3_tcxo` and `use_dio2_rf` for E22 modules.
 
 ## Uninstallation
 
+Read the [Uninstallation guide](https://docs.openhop.dev/projects/openhop-repeater/uninstallation/)
+and make a durable backup before continuing. The native uninstaller performs a
+complete removal after one confirmation: it deletes the current and legacy
+installation, configuration, logs, data, and the `repeater` service user.
+
 ```bash
 sudo bash ./manage.sh uninstall
 ```
 
-The uninstaller will:
-
-- Stop and disable the systemd service
-- Remove the installation directory
-- Optionally remove configuration, logs, and user data
-- Optionally remove the service user account
-
-The script prompts before each optional removal step.
+The script attempts a best-effort configuration-only backup under `/tmp`, but that
+is not a durable or complete backup and may be removed automatically. It does not
+prompt separately for individual paths. Docker Compose removal and persistent
+volume cleanup are separate operations covered by the guide.
 
 ## Docker Compose
 

--- a/manage.sh
+++ b/manage.sh
@@ -1363,7 +1363,7 @@ UPGRADEEOF
 
     local container_note=""
     if [ -f /run/host/container-manager ] || [ -n "${container:-}" ] || grep -qsai 'container=' /proc/1/environ 2>/dev/null || [ -f /.dockerenv ]; then
-        container_note="\n\n⚠ CONTAINER DETECTED:\nUSB udev rules must be set on the HOST, not here.\nSee documentation for CH341 host-side setup."
+        container_note="\n\n⚠ CONTAINER DETECTED:\nUSB udev rules must be set on the HOST, not here.\nCH341 host-side setup: https://docs.openhop.dev/projects/openhop-repeater/hardware-setup/#ch341-usb-spi-hosts"
     fi
 
     if [[ "$silent" == "true" ]]; then

--- a/tests/test_manage_script_documentation.py
+++ b/tests/test_manage_script_documentation.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+MANAGE_SCRIPT = Path(__file__).resolve().parents[1] / "manage.sh"
+CH341_HOST_SETUP_URL = (
+    "https://docs.openhop.dev/projects/openhop-repeater/hardware-setup/#ch341-usb-spi-hosts"
+)
+
+
+def test_container_upgrade_note_links_to_ch341_host_setup():
+    script = MANAGE_SCRIPT.read_text(encoding="utf-8")
+
+    assert f"CH341 host-side setup: {CH341_HOST_SETUP_URL}" in script
+    assert "See documentation for CH341 host-side setup." not in script


### PR DESCRIPTION
## Summary

Point openHop Repeater users to the central documentation now published at
[`docs.openhop.dev`](https://docs.openhop.dev/projects/openhop-repeater/).

This change:

- maps README documentation topics to specific central articles;
- replaces inaccurate uninstallation claims with the actual destructive behavior and
  durable-backup warning;
- makes the container upgrade warning actionable with a direct CH341 host-setup URL;
- adds a focused regression test for that user-facing URL.

## Central documentation migration

The destination articles were completed in
[openHop_docs#11](https://github.com/openhop-dev/openHop_docs/pull/11), grounded in
Repeater `dev` commit:

`d57baabf2e5069a2461b290a6586a3f57cafb20f`

README navigation now points to the relevant central articles for overview, dashboard,
hardware, installation, configuration, policy controls, upgrading, Proxmox/CH341,
uninstallation, Docker, and development rather than treating duplicate README sections
as the primary documentation system.

## Uninstallation correction

The previous README said configuration, logs, data, and the service user were optional
per-step removals. The actual `manage.sh uninstall` path uses one confirmation and then
removes current and legacy application/configuration/log/data paths and the service
user.

The README now links to the central
[Uninstallation guide](https://docs.openhop.dev/projects/openhop-repeater/uninstallation/)
and accurately warns that:

- removal is complete after one confirmation;
- the script's `/tmp` configuration copy is best-effort and not a durable or complete
  backup;
- Docker volume removal is a separate operation.

## CH341 container guidance

The upgrade completion message previously said only:

`See documentation for CH341 host-side setup.`

It now prints the actionable, safety-relevant destination:

`https://docs.openhop.dev/projects/openhop-repeater/hardware-setup/#ch341-usb-spi-hosts`

The linked section explains that container udev rules must be installed on the host.

## Generated RepeaterUI boundary

This backend repository still contains a generated frontend bundle with the old Wiki
Help link. It was intentionally not hand-edited here. The authoritative source is
`openHop_RepeaterUI/src/views/Help.vue`; that link needs a separate RepeaterUI source
change and verified frontend build. Keeping it out of this backend PR avoids creating a
fix that the next authoritative UI build would silently undo.

## Verification

- Full Repeater pytest suite passed.
- Focused CH341 documentation regression test passed.
- Changed-file pre-commit hooks passed, including Ruff, formatting, OpenAPI contract,
  Bandit selection, and pytest.
- `bash -n manage.sh` passed.
- All linked central routes returned HTTP 200.
- The CH341, upgrading, and Proxmox target anchors were found in the rendered central
  documentation.
- `git diff --check` passed.

Repository-wide Ruff currently reports pre-existing findings outside this patch; the
new test and changed-file gate pass. The existing PyMC Console release reference was
retained because it describes that separately bundled project, not a nonexistent
Repeater GitHub Release process.
