### PR TITLE
fix(update): never install a fabricated version

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -723,8 +723,11 @@ if ! [[ "$CHANNEL" =~ ^[a-zA-Z0-9._/-]{1,80}$ ]]; then
     exit 1
 fi
 # If caller supplied a version string, tell setuptools_scm to use it (sudo
-# strips env vars so it is passed as a positional argument instead).
-[ -n "$PRETEND_VERSION" ] && export SETUPTOOLS_SCM_PRETEND_VERSION="$PRETEND_VERSION"
+# strips env vars so it is passed as a positional argument instead). Scoped to
+# this distribution: the unscoped variable applies to every setuptools_scm
+# project built in the same pip run, so a dependency built from an sdist
+# instead of a wheel would be stamped with our version too.
+[ -n "$PRETEND_VERSION" ] && export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENHOP_REPEATER="$PRETEND_VERSION"
 # ---- Migration: ensure venv exists (handles upgrades from system-pip era) ----
 if [ ! -x "$VENV_PYTHON" ]; then
     echo "[pymc-do-upgrade] Creating venv at $VENV_DIR ..."
@@ -834,7 +837,7 @@ UPGRADEEOF
     # Only inspect git metadata when this directory is a checkout of the expected repo.
     if is_expected_repo_checkout "$SCRIPT_DIR"; then
         if GIT_VERSION="$(python3 -m setuptools_scm 2>/dev/null)"; then
-            export SETUPTOOLS_SCM_PRETEND_VERSION="$GIT_VERSION"
+            export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENHOP_REPEATER="$GIT_VERSION"
             echo "Installing version: $GIT_VERSION"
         fi
     fi
@@ -1075,7 +1078,7 @@ upgrade_repeater() {
 
     if is_expected_repo_checkout "$SCRIPT_DIR"; then
         if GIT_VERSION="$(python3 -m setuptools_scm 2>/dev/null)"; then
-            export SETUPTOOLS_SCM_PRETEND_VERSION="$GIT_VERSION"
+            export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENHOP_REPEATER="$GIT_VERSION"
             echo "Upgrading to version: $GIT_VERSION"
         fi
     fi
@@ -1212,8 +1215,11 @@ if ! [[ "$CHANNEL" =~ ^[a-zA-Z0-9._/-]{1,80}$ ]]; then
     exit 1
 fi
 # If caller supplied a version string, tell setuptools_scm to use it (sudo
-# strips env vars so it is passed as a positional argument instead).
-[ -n "$PRETEND_VERSION" ] && export SETUPTOOLS_SCM_PRETEND_VERSION="$PRETEND_VERSION"
+# strips env vars so it is passed as a positional argument instead). Scoped to
+# this distribution: the unscoped variable applies to every setuptools_scm
+# project built in the same pip run, so a dependency built from an sdist
+# instead of a wheel would be stamped with our version too.
+[ -n "$PRETEND_VERSION" ] && export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENHOP_REPEATER="$PRETEND_VERSION"
 # ---- Migration: ensure venv exists (handles upgrades from system-pip era) ----
 if [ ! -x "$VENV_PYTHON" ]; then
     echo "[pymc-do-upgrade] Creating venv at $VENV_DIR ..."

--- a/repeater/web/update_endpoints.py
+++ b/repeater/web/update_endpoints.py
@@ -671,6 +671,13 @@ def _has_update(installed: str, latest: str) -> bool:
 
 
 def _fetch_latest_version(channel: str) -> str:
+    """Return the version currently published on ``channel``.
+
+    Raises when the version cannot be determined. Returning an approximation
+    (such as the newest tag) would be actively harmful: the caller stores this
+    value as the channel's latest version, so a wrong value both misreports
+    the update state and gets baked into the install as the built version.
+    """
 
     base_tag = _get_latest_tag()  # always needed for dynamic branches
 
@@ -680,22 +687,28 @@ def _fetch_latest_version(channel: str) -> str:
             body = _fetch_url(compare_url, timeout=10)
             data = json.loads(body)
             ahead_by = int(data.get("ahead_by", 0))
-            return _next_dev_version(base_tag, ahead_by)
+        except _RateLimitError:
+            raise
         except Exception as exc:
-            logger.debug(f"[Update] Dynamic version compare failed for {channel!r}: {exc}")
-            return base_tag  # fallback: show the tag
+            raise RuntimeError(
+                f"Could not compare {base_tag}...{channel} on GitHub: {exc}"
+            ) from exc
+        return _next_dev_version(base_tag, ahead_by)
 
     # Static version channel — read the pinned version from pyproject.toml on
     # that branch directly, so tags created on other branches don't affect it.
     try:
         toml_url = f"{GITHUB_RAW_BASE}/{channel}/pyproject.toml"
         toml_text = _fetch_url(toml_url, timeout=8)
-        m = re.search(r'^version\s*=\s*["\']([0-9][^"\']*)["\']', toml_text, re.MULTILINE)
-        if m:
-            return m.group(1)
+    except _RateLimitError:
+        raise
     except Exception as exc:
-        logger.debug(f"[Update] Static version lookup failed for {channel!r}: {exc}")
-    return base_tag  # last-resort fallback
+        raise RuntimeError(f"Could not read pyproject.toml from {channel}: {exc}") from exc
+
+    m = re.search(r'^version\s*=\s*["\']([0-9][^"\']*)["\']', toml_text, re.MULTILINE)
+    if not m:
+        raise RuntimeError(f"No pinned version found in pyproject.toml on {channel}")
+    return m.group(1)
 
 
 def _fetch_changelog(channel: str, installed: str, max_commits: int = 50) -> List[dict]:
@@ -932,8 +945,13 @@ def _do_install() -> None:
 
     import os as _os
 
+    # No SETUPTOOLS_SCM_PRETEND_VERSION here: the version reported by the last
+    # check is a prediction, and pip derives the real one from the checkout it
+    # clones. Forcing the predicted value stamped the build with a version that
+    # did not match its code — and when that value was stale (a failed check, or
+    # a channel switch) pip saw the requirement as already satisfied and skipped
+    # the install, pinning the node to a version it could no longer leave.
     env = _os.environ.copy()
-    env["SETUPTOOLS_SCM_PRETEND_VERSION"] = _state.latest_version or "1.0.0"
 
     _VENV_DIR = "/opt/openhop_repeater/venv"
     _VENV_PIP = os.path.join(_VENV_DIR, "bin", "pip")
@@ -991,7 +1009,8 @@ def _do_install() -> None:
     elif _os.path.isfile(_UPGRADE_WRAPPER):
         _state.append_line(f"[pyMC updater] Using sudo wrapper: {_UPGRADE_WRAPPER}")
         # The wrapper handles venv creation/migration internally
-        cmd = [_SUDO_BIN, _UPGRADE_WRAPPER, channel, _state.latest_version or ""]
+        # Second argument (pretend-version) deliberately omitted — see above.
+        cmd = [_SUDO_BIN, _UPGRADE_WRAPPER, channel]
     else:
         msg = (
             f"Upgrade wrapper not found at {_UPGRADE_WRAPPER}. "

--- a/tests/test_update_endpoints_unit.py
+++ b/tests/test_update_endpoints_unit.py
@@ -470,3 +470,107 @@ def test_do_install_wrapper_success_container_path(isolated_state, monkeypatch):
     assert st.state == "complete"
     assert st.error_message is None
     assert any("container will restart" in line for line in st.progress_lines)
+
+
+def test_fetch_latest_version_refuses_to_guess_on_failure(monkeypatch):
+    # The value returned here is stored as the channel's latest version and is
+    # what the UI compares against, so a guess is worse than an error.
+    monkeypatch.setattr(ue, "_get_latest_tag", lambda: "1.1.1")
+    monkeypatch.setattr(ue, "_branch_is_dynamic", lambda _ch: True)
+    monkeypatch.setattr(
+        ue,
+        "_fetch_url",
+        lambda _url, timeout=10: (_ for _ in ()).throw(RuntimeError("compare unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="Could not compare"):
+        ue._fetch_latest_version("dev")
+
+
+def test_fetch_latest_version_propagates_rate_limit(monkeypatch):
+    # A rate-limited check must reach _do_check as a _RateLimitError so the
+    # existing backoff path runs instead of being reported as a version.
+    monkeypatch.setattr(ue, "_get_latest_tag", lambda: "1.1.1")
+    monkeypatch.setattr(ue, "_branch_is_dynamic", lambda _ch: True)
+    monkeypatch.setattr(
+        ue,
+        "_fetch_url",
+        lambda _url, timeout=10: (_ for _ in ()).throw(ue._RateLimitError("limited")),
+    )
+
+    with pytest.raises(ue._RateLimitError):
+        ue._fetch_latest_version("dev")
+
+
+def test_fetch_latest_version_static_channel_without_pin_raises(monkeypatch):
+    monkeypatch.setattr(ue, "_get_latest_tag", lambda: "1.1.1")
+    monkeypatch.setattr(ue, "_branch_is_dynamic", lambda _ch: False)
+    monkeypatch.setattr(ue, "_fetch_url", lambda _url, timeout=8: 'name = "x"\n')
+
+    with pytest.raises(RuntimeError, match="No pinned version"):
+        ue._fetch_latest_version("main")
+
+
+def _capturing_popen(monkeypatch, calls):
+    class _Proc:
+        def __init__(self, cmd, env):
+            calls.append({"cmd": cmd, "env": env or {}})
+            self.stdout = ["ok\n"]
+            self.returncode = 0
+
+        def wait(self):
+            return None
+
+    monkeypatch.setattr(ue.subprocess, "Popen", lambda cmd, **kwargs: _Proc(cmd, kwargs.get("env")))
+
+
+def test_do_install_root_does_not_force_a_predicted_version(isolated_state, monkeypatch):
+    st = isolated_state
+    st.channel = "dev"
+    # A stale prediction, e.g. left by a check that fell back to a tag.
+    st.latest_version = "1.1.1"
+
+    monkeypatch.setattr(ue.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(ue, "is_buildroot", lambda: False)
+    monkeypatch.setattr(ue, "is_container", lambda: False)
+    monkeypatch.setattr(ue, "_migrate_service_unit", lambda: None)
+    monkeypatch.setattr(ue, "_disable_legacy_services", lambda: None)
+    monkeypatch.setattr(ue, "_cleanup_stale_dist_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ue.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(ue.os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(ue.time, "sleep", lambda _s: None)
+    monkeypatch.setattr("repeater.service_utils.restart_service", lambda: (True, "ok"))
+
+    calls = []
+    _capturing_popen(monkeypatch, calls)
+
+    ue._do_install()
+
+    assert calls, "expected the installer to run at least one command"
+    for call in calls:
+        assert "SETUPTOOLS_SCM_PRETEND_VERSION" not in call["env"]
+    install = [c for c in calls if any("git+https://github.com" in str(x) for x in c["cmd"])]
+    assert install, "expected a pip install from git"
+    assert any("@dev" in str(x) for x in install[-1]["cmd"])
+
+
+def test_do_install_wrapper_call_omits_pretend_version(isolated_state, monkeypatch):
+    st = isolated_state
+    st.channel = "dev"
+    st.latest_version = "1.1.1"
+
+    monkeypatch.setattr(ue.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(ue, "is_buildroot", lambda: False)
+    monkeypatch.setattr(ue, "is_container", lambda: False)
+    monkeypatch.setattr(ue, "_cleanup_stale_dist_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ue.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(ue.os.path, "isfile", lambda p: p == "/usr/local/bin/pymc-do-upgrade")
+    monkeypatch.setattr("repeater.service_utils.restart_service", lambda: (True, "ok"))
+
+    calls = []
+    _capturing_popen(monkeypatch, calls)
+
+    ue._do_install()
+
+    assert calls[-1]["cmd"] == [ue._SUDO_BIN, "/usr/local/bin/pymc-do-upgrade", "dev"]
+    assert "SETUPTOOLS_SCM_PRETEND_VERSION" not in calls[-1]["env"]


### PR DESCRIPTION
## Problem

Two defects in the OTA updater combine to pin a repeater to a version it can no longer leave, while the UI reports it as up to date.

### 1. A failed version lookup is reported as a version

`_fetch_latest_version()` returns the newest repository tag whenever the GitHub lookup fails:

```python
try:
    body = _fetch_url(compare_url, timeout=10)
    ...
except Exception as exc:
    logger.debug(f"[Update] Dynamic version compare failed for {channel!r}: {exc}")
    return base_tag  # fallback: show the tag
```

For a dynamic channel such as `dev`, that tag comes from a different branch entirely, so the value is not an approximation — it is the version of something else. The caller stores it as the channel's latest version, and the UI then compares against it.

The blanket `except Exception` also swallows `_RateLimitError`. That class exists precisely so `_do_check()` can take the `_fail_check_ratelimit()` path (keep the existing version data, record the reset time, stop hammering GitHub); for dynamic channels that path could never run.

### 2. The predicted version becomes the built version

`_do_install()` passed the value from the last check to setuptools_scm:

```python
env["SETUPTOOLS_SCM_PRETEND_VERSION"] = _state.latest_version or "1.0.0"
...
cmd = [_SUDO_BIN, _UPGRADE_WRAPPER, channel, _state.latest_version or ""]
```

pip installs the channel's code but records the *predicted* version as the installed one. Once a wrong prediction has been baked in, the requirement resolves as already satisfied on every later run — pip re-clones the git dependency, computes the same version it already has, and skips the install. Force Reinstall included: it only bypasses the `has_update` gate, the pip command is identical.

`"1.0.0"` is used when no check has ever succeeded, which stamps a fresh install with a version that has never existed.

### Field evidence

A node tracking `dev`:

| UI field | Value |
|---|---|
| Installed | 1.1.1 |
| On GitHub | 1.1.1 |
| Status | *You are up to date. Use Force Reinstall to reinstall anyway.* |
| Release channel | dev |

`dev` was at `1.1.2.dev201` at the time. The node was running `dev` code labelled `1.1.1` — the label came from an install performed while a check had fallen back to the tag. Force Reinstall changed nothing, and no upgrade could ever be offered again: every future check compares the channel against a version that never matches it.

## Change

- **`_fetch_latest_version()` raises instead of guessing.** `_RateLimitError` propagates so the existing backoff path runs; anything else becomes a `RuntimeError`, which `_do_check()` already surfaces as a failed check. A check that cannot reach GitHub is now reported as a check that failed, not as a version.
- **`_do_install()` no longer injects a version.** pip derives the real one from the checkout it clones. The wrapper's second argument is dropped; this is backward compatible with wrappers already deployed, since `PRETEND_VERSION="${2:-}"` and the `[ -n "$PRETEND_VERSION" ]` guard make the omission a no-op.
- **`manage.sh` pretend-version uses are scoped** to `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENHOP_REPEATER`. The unscoped variable applies to every setuptools_scm-based project built in the same pip invocation, not only ours. Dependencies normally arrive as wheels and are unaffected, but one built from an sdist inherits our version:

  ```console
  $ SETUPTOOLS_SCM_PRETEND_VERSION=9.9.9 pip wheel --no-deps portend-3.2.1.tar.gz
  portend-9.9.9-py3-none-any.whl

  $ SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENHOP_REPEATER=9.9.9 pip wheel --no-deps portend-3.2.1.tar.gz
  portend-3.2.1-py3-none-any.whl
  ```

  `portend` and `jaraco.functools` (both in the CherryPy chain) build with setuptools_scm. `openhop_core` pins its version statically, so it was never affected. `buildroot-manage.sh` already exports the scoped variant, so this aligns the three scripts.

The manual `sudo pymc-do-upgrade <channel> <version>` interface is unchanged for anyone using it deliberately.

## Recovering a node that is already stuck

The fix cannot reach a stuck node through the updater, since the updater is what is stuck. One-time, from a shell:

```bash
sudo /opt/openhop_repeater/venv/bin/pip install --upgrade --no-cache-dir \
  "openhop_repeater[hardware] @ git+https://github.com/openhop-dev/openhop_repeater.git@dev"
sudo systemctl restart openhop-repeater
```

## Test plan

- [x] 5 new unit tests in `tests/test_update_endpoints_unit.py` covering both defects: lookup failure raises, rate limit propagates, static channel without a pin raises, and neither install path emits `SETUPTOOLS_SCM_PRETEND_VERSION` or a pretend-version argument. All five fail on `dev` and pass here.
- [x] Full suite: 1464 passed. One pre-existing unrelated failure (`test_text_helper_real_crypto_consume_vs_collision_forward`) fails identically on `dev`. `tests/test_companion_ws_proxy.py` was not collected locally (no `ws4py` in my environment).
- [x] `ruff check`: 52 findings vs 54 on `dev` for the touched files — two blind-`except` sites removed, no new codes. `ruff format --check` clean, OpenAPI contract check passes.
- [x] `bash -n manage.sh`.
- [ ] Not verified by me: the Buildroot install path. `prepare_git_version()` in `buildroot-manage.sh` computes and exports its own version from the checkout, so dropping the env variable in `_do_install()` should be inert there, but I have no Buildroot image to confirm on.

## Not included

Force Reinstall remains a no-op when the installed version genuinely equals the channel's version — the button bypasses the `has_update` gate but sends the same pip command. Making it actually forceful means passing `--force-reinstall`, which has to travel through the sudo wrapper; deployed wrappers would ignore a new argument until `manage.sh` regenerates them, so the behaviour would differ between root and non-root installs. That seemed worth its own change rather than bundling here.

