### PR TITLE
fix(neighbors): age ghosts out of the published zero-hop table

### DIFF
--- a/repeater/data_acquisition/sqlite_handler.py
+++ b/repeater/data_acquisition/sqlite_handler.py
@@ -159,7 +159,8 @@ class SQLiteHandler:
                         snr REAL,
                         advert_count INTEGER NOT NULL DEFAULT 1,
                         is_new_neighbor BOOLEAN NOT NULL,
-                        zero_hop BOOLEAN NOT NULL DEFAULT FALSE
+                        zero_hop BOOLEAN NOT NULL DEFAULT FALSE,
+                        last_zero_hop_seen REAL
                     )
                 """
                 )
@@ -817,6 +818,37 @@ class SQLiteHandler:
                     )
                     logger.info(f"Migration '{migration_name}' applied successfully")
 
+                # Migration 17: When a node was last heard DIRECTLY. The zero_hop
+                # flag is sticky by design (it also guards the preserved zero-hop
+                # rssi/snr), but last_seen refreshes on every advert including
+                # relayed ones, so "zero_hop AND fresh last_seen" cannot express
+                # "currently a zero-hop neighbour" — a node heard directly once
+                # stays in that cohort for as long as its multi-hop floods keep
+                # arriving. This column is the timestamp the flag was missing.
+                # Backfilled from last_seen for existing zero_hop rows (the best
+                # information available); stale entries age out within one
+                # max_neighbor_age window instead of being dropped on upgrade.
+                migration_name = "add_last_zero_hop_seen_to_adverts"
+                existing = conn.execute(
+                    "SELECT migration_name FROM migrations WHERE migration_name = ?",
+                    (migration_name,),
+                ).fetchone()
+                if not existing:
+                    cursor = conn.execute("PRAGMA table_info(adverts)")
+                    columns = [column[1] for column in cursor.fetchall()]
+                    if "last_zero_hop_seen" not in columns:
+                        conn.execute("ALTER TABLE adverts ADD COLUMN last_zero_hop_seen REAL")
+                        logger.info("Added last_zero_hop_seen column to adverts table")
+                    conn.execute(
+                        "UPDATE adverts SET last_zero_hop_seen = last_seen "
+                        "WHERE zero_hop = 1 AND last_zero_hop_seen IS NULL"
+                    )
+                    conn.execute(
+                        "INSERT INTO migrations (migration_name, applied_at) VALUES (?, ?)",
+                        (migration_name, time.time()),
+                    )
+                    logger.info(f"Migration '{migration_name}' applied successfully")
+
                 conn.commit()
 
         except Exception as e:
@@ -1090,7 +1122,9 @@ class SQLiteHandler:
             with self._connect() as conn:
                 conn.row_factory = sqlite3.Row
                 existing = conn.execute(
-                    "SELECT pubkey, first_seen, advert_count, zero_hop, rssi, snr FROM adverts WHERE pubkey = ? ORDER BY last_seen DESC LIMIT 1",
+                    "SELECT pubkey, first_seen, advert_count, zero_hop, rssi, snr, "
+                    "last_zero_hop_seen FROM adverts WHERE pubkey = ? "
+                    "ORDER BY last_seen DESC LIMIT 1",
                     (record.get("pubkey", ""),),
                 ).fetchone()
 
@@ -1105,18 +1139,25 @@ class SQLiteHandler:
                     # - If incoming is zero-hop: ALWAYS store incoming rssi/snr (most recent zero-hop measurement)
                     # - If incoming is multi-hop and existing was zero-hop: preserve existing (don't overwrite zero-hop with multi-hop)
                     # - If both are multi-hop: signal measurements are not applicable
+                    # last_zero_hop_seen advances only on direct receptions, so
+                    # "currently a zero-hop neighbour" stays answerable even
+                    # though zero_hop is sticky and last_seen refreshes on
+                    # relayed adverts too.
                     if incoming_zero_hop:
                         rssi_to_store = record.get("rssi")
                         snr_to_store = record.get("snr")
                         zero_hop_to_store = True
+                        last_zero_hop_seen = current_time
                     elif existing_zero_hop:
                         rssi_to_store = existing["rssi"]
                         snr_to_store = existing["snr"]
                         zero_hop_to_store = True
+                        last_zero_hop_seen = existing["last_zero_hop_seen"]
                     else:
                         rssi_to_store = None
                         snr_to_store = None
                         zero_hop_to_store = False
+                        last_zero_hop_seen = None
 
                     conn.execute(
                         """
@@ -1124,7 +1165,7 @@ class SQLiteHandler:
                         SET timestamp = ?, node_name = ?, is_repeater = ?, route_type = ?,
                             contact_type = ?, latitude = ?, longitude = ?, last_seen = ?,
                             rssi = ?, snr = ?, advert_count = advert_count + 1, is_new_neighbor = 0,
-                            zero_hop = ?
+                            zero_hop = ?, last_zero_hop_seen = ?
                         WHERE pubkey = ?
                     """,
                         (
@@ -1139,6 +1180,7 @@ class SQLiteHandler:
                             rssi_to_store,
                             snr_to_store,
                             zero_hop_to_store,
+                            last_zero_hop_seen,
                             record.get("pubkey", ""),
                         ),
                     )
@@ -1148,8 +1190,8 @@ class SQLiteHandler:
                         INSERT INTO adverts (
                             timestamp, pubkey, node_name, is_repeater, route_type, contact_type,
                             latitude, longitude, first_seen, last_seen, rssi, snr, advert_count,
-                            is_new_neighbor, zero_hop
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            is_new_neighbor, zero_hop, last_zero_hop_seen
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                         (
                             current_time,
@@ -1167,6 +1209,7 @@ class SQLiteHandler:
                             1,
                             True,
                             record.get("zero_hop", False),
+                            current_time if record.get("zero_hop", False) else None,
                         ),
                     )
 
@@ -2555,11 +2598,13 @@ class SQLiteHandler:
                 neighbors = conn.execute(
                     """
                     SELECT pubkey, node_name, is_repeater, route_type, contact_type,
-                           latitude, longitude, first_seen, last_seen, rssi, snr, advert_count, zero_hop
+                           latitude, longitude, first_seen, last_seen, rssi, snr, advert_count,
+                           zero_hop, last_zero_hop_seen
                     FROM (
                         SELECT
                             pubkey, node_name, is_repeater, route_type, contact_type,
-                            latitude, longitude, first_seen, last_seen, rssi, snr, advert_count, zero_hop,
+                            latitude, longitude, first_seen, last_seen, rssi, snr, advert_count,
+                            zero_hop, last_zero_hop_seen,
                             ROW_NUMBER() OVER (PARTITION BY pubkey ORDER BY last_seen DESC) AS rn
                         FROM adverts
                     ) latest
@@ -2583,6 +2628,7 @@ class SQLiteHandler:
                         "snr": row["snr"],
                         "advert_count": row["advert_count"],
                         "zero_hop": bool(row["zero_hop"]),
+                        "last_zero_hop_seen": row["last_zero_hop_seen"],
                     }
 
                 self._neighbors_cache = {"timestamp": now, "value": result}

--- a/repeater/neighbors_publisher.py
+++ b/repeater/neighbors_publisher.py
@@ -711,7 +711,12 @@ class NeighborsPublisher:
                         continue
                     return NeighborSnapshot(
                         pubkey=pubkey,
-                        last_seen=float(info.get("last_seen") or 0.0),
+                        # Same source the cycle snapshot uses: the last DIRECT
+                        # reception when known, so both paths describe the
+                        # neighbour identically.
+                        last_seen=float(
+                            info.get("last_zero_hop_seen") or info.get("last_seen") or 0.0
+                        ),
                         snr=float(info.get("snr") or 0.0),
                     )
             except Exception as e:
@@ -785,6 +790,11 @@ class NeighborsPublisher:
         table does) merged with this cycle's discovery responses, which win on
         ``last_seen``/``snr`` because they are first-hand and the table read is
         served from a cache the advert write does not invalidate.
+
+        "Heard via advert" means heard DIRECTLY via advert: freshness is judged
+        on ``last_zero_hop_seen``, so a formerly-direct neighbour whose relayed
+        floods keep refreshing ``last_seen`` ages out of this table like it does
+        out of the firmware's (whose entries only ever update on direct events).
         """
         storage = self._storage()
         neighbors = {}
@@ -806,10 +816,21 @@ class NeighborsPublisher:
             if len(key) != 64:
                 # Scope queries need the full key for ECDH; a prefix cannot be used.
                 continue
-            last_seen = float(info.get("last_seen") or 0.0)
-            if last_seen <= 0 or (now - last_seen) > max_age:
+            # Freshness is judged on the last DIRECT reception, not last_seen:
+            # zero_hop is sticky and last_seen refreshes on relayed adverts too,
+            # so a node heard directly once would otherwise stay in the table
+            # for as long as its multi-hop floods keep arriving — published with
+            # a fresh-looking heard_secs_ago next to a months-old snr. Falls
+            # back to last_seen when the value is absent OR null — null covers
+            # zero_hop rows written by a downgraded binary after the migration
+            # already ran, and matches the fallback GET_NEIGHBOURS and the CLI
+            # use, so the three views agree on such rows.
+            direct_seen = float(info.get("last_zero_hop_seen") or info.get("last_seen") or 0.0)
+            if direct_seen <= 0 or (now - direct_seen) > max_age:
                 continue
-            merged[key] = {"last_seen": last_seen, "snr": float(info.get("snr") or 0.0)}
+            # heard_secs_ago and the ordering derive from this too, keeping the
+            # published row self-consistent with its zero-hop-only snr.
+            merged[key] = {"last_seen": direct_seen, "snr": float(info.get("snr") or 0.0)}
 
         for key, seen in (self._discovery_seen or {}).items():
             merged[key] = dict(seen)

--- a/tests/test_mqtt_neighbors.py
+++ b/tests/test_mqtt_neighbors.py
@@ -717,6 +717,26 @@ def test_snapshot_filters_to_fresh_zero_hop_repeaters():
                 "snr": 9.0,
             },
             "ee": {"is_repeater": True, "zero_hop": True, "last_seen": now, "snr": 9.0},
+            # The sticky-flag ghost: heard directly once long ago, and its
+            # relayed floods keep refreshing last_seen. zero_hop stays True by
+            # design, so only last_zero_hop_seen can age it out of this table.
+            "ff" * 32: {
+                "is_repeater": True,
+                "zero_hop": True,
+                "last_seen": now,
+                "last_zero_hop_seen": now - 100000,
+                "snr": 9.0,
+            },
+            # Null timestamp (e.g. a row written by a downgraded binary after
+            # the migration already ran): falls back to last_seen like a row
+            # without the column, consistently with GET_NEIGHBOURS and the CLI.
+            "99" * 32: {
+                "is_repeater": True,
+                "zero_hop": True,
+                "last_seen": now,
+                "last_zero_hop_seen": None,
+                "snr": 3.0,
+            },
             local_key: {"is_repeater": True, "zero_hop": True, "last_seen": now, "snr": 9.0},
         }
     )
@@ -724,8 +744,33 @@ def test_snapshot_filters_to_fresh_zero_hop_repeaters():
 
     snapshot = publisher._snapshot_neighbors()
 
-    # Multi-hop, non-repeater, stale, short-key and self rows are all excluded.
-    assert [s.pubkey for s in snapshot] == ["aa" * 32]
+    # Multi-hop, non-repeater, stale, short-key, stale-direct and self rows
+    # are all excluded. Rows without last_zero_hop_seen (aa) or with a null
+    # one (99) fall back to last_seen, which is the pre-column behavior.
+    assert [s.pubkey for s in snapshot] == ["aa" * 32, "99" * 32]
+
+
+def test_snapshot_heard_time_is_the_last_direct_reception():
+    """heard_secs_ago must describe the last DIRECT contact, consistent with
+    the zero-hop-only snr beside it, not the multi-hop-refreshed last_seen."""
+    now = time.time()
+    storage = SimpleNamespace(
+        get_neighbors=lambda: {
+            "aa" * 32: {
+                "is_repeater": True,
+                "zero_hop": True,
+                "last_seen": now,  # refreshed by a relayed flood
+                "last_zero_hop_seen": now - 700,  # last direct reception
+                "snr": 4.0,
+            }
+        }
+    )
+    publisher = _publisher({"mqtt_brokers": {}}, storage=storage)
+
+    snapshot = publisher._snapshot_neighbors()
+
+    assert len(snapshot) == 1
+    assert snapshot[0].last_seen == now - 700
 
 
 def test_snapshot_merges_this_cycle_discovery_over_the_cached_table():

--- a/tests/test_sqlite_handler_easy.py
+++ b/tests/test_sqlite_handler_easy.py
@@ -419,7 +419,8 @@ def test_store_advert_zero_hop_signal_handling(tmp_path):
     )
     with h._connect() as conn:
         row = conn.execute(
-            "SELECT rssi, snr, zero_hop, advert_count FROM adverts WHERE pubkey = ?",
+            "SELECT rssi, snr, zero_hop, advert_count, last_seen, last_zero_hop_seen "
+            "FROM adverts WHERE pubkey = ?",
             ("pk-z",),
         ).fetchone()
     assert row is not None
@@ -427,6 +428,10 @@ def test_store_advert_zero_hop_signal_handling(tmp_path):
     assert row[1] == 5.0
     assert bool(row[2]) is True
     assert row[3] == 2
+    # last_seen follows every advert; last_zero_hop_seen only direct ones. This
+    # pair is what lets consumers tell a current neighbour from a sticky flag.
+    assert row[4] == 20.0
+    assert row[5] == 10.0
 
     # New zero-hop update should refresh signal quality.
     h.store_advert(
@@ -445,7 +450,8 @@ def test_store_advert_zero_hop_signal_handling(tmp_path):
     )
     with h._connect() as conn:
         row2 = conn.execute(
-            "SELECT rssi, snr, zero_hop, advert_count FROM adverts WHERE pubkey = ?",
+            "SELECT rssi, snr, zero_hop, advert_count, last_zero_hop_seen "
+            "FROM adverts WHERE pubkey = ?",
             ("pk-z",),
         ).fetchone()
     assert row2 is not None
@@ -453,6 +459,49 @@ def test_store_advert_zero_hop_signal_handling(tmp_path):
     assert row2[1] == 6.5
     assert bool(row2[2]) is True
     assert row2[3] == 3
+    assert row2[4] == 30.0  # direct reception advances the timestamp
+
+    # get_neighbors must expose the column for the neighbours publisher.
+    neighbors = h.get_neighbors()
+    assert neighbors["pk-z"]["last_zero_hop_seen"] == 30.0
+
+
+def test_migration_backfills_last_zero_hop_seen(tmp_path):
+    """Upgrading a DB with sticky zero_hop rows seeds last_zero_hop_seen from
+    last_seen (best information available), so existing genuine neighbours are
+    not dropped from the publisher table on upgrade."""
+    h = _make_handler(tmp_path)
+
+    h.store_advert(
+        {
+            "timestamp": 10.0,
+            "pubkey": "pk-m",
+            "node_name": "node-m",
+            "is_repeater": True,
+            "route_type": 1,
+            "contact_type": "repeater",
+            "is_new_neighbor": True,
+            "zero_hop": True,
+        }
+    )
+
+    # Simulate a pre-column database: null the value and forget the migration.
+    with h._connect() as conn:
+        conn.execute("UPDATE adverts SET last_zero_hop_seen = NULL")
+        conn.execute(
+            "DELETE FROM migrations WHERE migration_name = 'add_last_zero_hop_seen_to_adverts'"
+        )
+        conn.commit()
+
+    h._run_migrations()
+
+    with h._connect() as conn:
+        row = conn.execute(
+            "SELECT last_seen, last_zero_hop_seen FROM adverts WHERE pubkey = ?",
+            ("pk-m",),
+        ).fetchone()
+    assert row is not None
+    assert row[1] == row[0]  # backfilled from last_seen
 
 
 def test_sync_transport_keys_validation_and_tree_apply(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

The MQTT neighbours publisher — and the UI text beside its toggle — promise a table of **current zero-hop neighbours** ("discovers zero-hop neighbours and their region scopes, then publishes the table to the neighbors topic"). The mechanics are genuinely zero-hop: discovery request/response are `route_type=direct` with an empty path, and adverts mark `zero_hop = (path_len == 0)` at ingestion. But the freshness filter cannot deliver on the promise:

- `adverts.zero_hop` is **sticky by design** (`sqlite_handler.store_advert`: once True, always True — it also guards the preserved zero-hop rssi/snr measurements);
- `adverts.last_seen` refreshes on **every** advert, relayed ones included.

So the publisher's filter (`zero_hop AND last_seen < max_neighbor_age`) matches any repeater that was heard directly **once** — a portable node passing by, a propagation lift, an old antenna position — for as long as its multi-hop floods keep arriving:

- it stays in the published table **indefinitely**, presented with a fresh-looking `heard_secs_ago` (multi-hop-refreshed) next to a months-old `snr` (zero-hop-only by design);
- consumers of the `neighbors` topic (adjacency/scope maps) inherit **false RF-adjacency edges** they cannot detect (apart from the tell-tale perpetual `status: "timeout"`);
- ghosts compete for the `max_neighbors=32` cap — ordered by the contaminated `last_seen`, they can evict genuine zero-hop neighbours from both the table and the scope sweep;
- each ghost burns one guaranteed-timeout anon scope query per cycle (airtime), since scope queries are themselves zero-hop-only.

The firmware this module ports (`simple_repeater/MyMesh.cpp`, `WITH_MQTT_NEIGHBORS`) does not have the problem: its `neighbours[]` entries only ever update on direct events, so stale ones age out naturally.

## Change

New `adverts.last_zero_hop_seen` column, advanced **only on direct receptions** (path_len == 0 adverts and node-discovery responses — both go through `store_advert`). Multi-hop adverts keep refreshing `last_seen` but leave it untouched.

- `NeighborsPublisher._snapshot_neighbors()` judges freshness on `last_zero_hop_seen`, and derives `heard_secs_ago` and the table ordering from it — every published row is now self-consistent with its zero-hop-only `snr`.
- The sticky `zero_hop` flag is **untouched**: it still means "has been heard directly" for the UI and still guards the signal-measurement preservation logic.
- Migration backfills the column from `last_seen` for existing `zero_hop` rows (the best information available): genuine neighbours survive the upgrade, ghosts age out within one `max_neighbor_age` window (24 h default) instead of being dropped abruptly.
- Rows from storage backends without the column fall back to `last_seen` — exactly the old behavior.
- `query_one` snapshots borrow the same timestamp, so both paths describe a neighbour identically.

## Out of scope (follow-up candidates)

Now addressed by the stacked follow-up #399 (GET_NEIGHBOURS over RF, mesh CLI, and the adverts endpoint feeding the web map) and openhop-dev/openHop_RepeaterUI#98 (map lines, table badge+sort, details modal, default filter).

## Test plan

- [x] `pytest tests/test_mqtt_neighbors.py tests/test_sqlite_handler_easy.py tests/test_companion_advert_persistence.py tests/test_handler_helpers_acl_advert.py tests/test_path_hash_mode_advert.py` — 189 passed. New coverage: the sticky-ghost row is excluded while a fresh direct row stays; `heard_secs_ago` derives from the last direct reception; `store_advert` advances the timestamp on direct and preserves it on multi-hop; migration backfill; `get_neighbors` exposure; fallback for column-less storage stubs (existing tests pass unmodified through it)
- [x] `pytest tests/test_mqtt_publish_integration.py tests/test_api_endpoints_core_coverage.py` — 90 passed
- [x] `ruff check` / `ruff format --check` — zero new findings (strict parity with dev)
