### PR TITLE
fix(engine): release the seen-table entry when the transmit never happens

### DIFF
--- a/repeater/engine.py
+++ b/repeater/engine.py
@@ -97,11 +97,17 @@ class ForwardResult(tuple):
     optional multi-ack redundancy copies ahead of the plain ACK at the same
     scheduled time, so the caller must create the extra TX tasks before the
     primary one.
+
+    ``seen_key`` is the seen-table entry this decision reserved, so ``__call__``
+    can release it if the transmit never happens.  It must be the exact key the
+    branch marked with: a TRACE packet folds path_len into its hash, so a key
+    recomputed after the path is appended no longer matches.
     """
 
-    def __new__(cls, packet: Packet, delay_s: float, extras=()):
+    def __new__(cls, packet: Packet, delay_s: float, extras=(), seen_key=None):
         result = super().__new__(cls, (packet, delay_s))
         result.extras = tuple(extras)
+        result.seen_key = seen_key
         return result
 
 
@@ -362,10 +368,14 @@ class RepeaterHandler(BaseHandler):
         )
         forwarded_path_hashes = None
 
+        # Seen-table entry reserved by the forward decision below, released again
+        # if the transmit never happens (see the rollback after the TX block).
+        seen_key = getattr(result, "seen_key", None)
+
         # For local transmissions, create a direct transmission result (if local TX allowed)
         if local_transmission and allow_local_tx:
             # Mark local packet as seen to prevent duplicate processing when received back
-            self.mark_seen(packet, packet_hash=pkt_hash_full)
+            seen_key = self.mark_seen(packet, packet_hash=pkt_hash_full)
             # Calculate transmission delay for local packets
             delay = self._calculate_tx_delay(packet, snr)
             result = (packet, delay)
@@ -373,64 +383,113 @@ class RepeaterHandler(BaseHandler):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"Local transmission: calculated delay {delay:.3f}s")
 
-        if result:
-            fwd_pkt, delay = result
-            tx_delay_ms = delay * 1000.0
+        # One release point for every way the block below can end — return,
+        # drop, or exception — so a new failure path cannot forget it.
+        try:
+            if result:
+                fwd_pkt, delay = result
+                tx_delay_ms = delay * 1000.0
 
-            # Capture the forwarded path (after modification)
-            forwarded_path_hashes = fwd_pkt.get_path_hashes_hex()
+                # Capture the forwarded path (after modification)
+                forwarded_path_hashes = fwd_pkt.get_path_hashes_hex()
 
-            # MeshCore queues multi-ack redundancy copies ahead of the primary
-            # ACK at the same scheduled time, so create their TX tasks first.
-            # Each task re-checks the duty-cycle gate before transmitting.
-            extra_tx_tasks = []
-            for extra_pkt, extra_delay in getattr(result, "extras", ()):
-                extra_airtime_ms = self.airtime_mgr.calculate_airtime(extra_pkt.get_raw_length())
-                extra_tx_tasks.append(
-                    await self.schedule_retransmit(
-                        extra_pkt,
-                        extra_delay,
-                        extra_airtime_ms,
-                        preferred_tx_radio_id=preferred_tx_radio_id,
+                # MeshCore queues multi-ack redundancy copies ahead of the primary
+                # ACK at the same scheduled time, so create their TX tasks first.
+                # Each task re-checks the duty-cycle gate before transmitting.
+                extra_tx_tasks = []
+                for extra_pkt, extra_delay in getattr(result, "extras", ()):
+                    extra_airtime_ms = self.airtime_mgr.calculate_airtime(
+                        extra_pkt.get_raw_length()
                     )
-                )
-
-            # Check duty-cycle before scheduling TX
-            airtime_ms = self.airtime_mgr.calculate_airtime(fwd_pkt.get_raw_length())
-
-            can_tx, wait_time = self.airtime_mgr.can_transmit(airtime_ms)
-
-            # LBT metadata (set after any TX path that awaits send)
-            tx_metadata = None
-            lbt_attempts = 0
-            lbt_backoff_delays_ms = None
-            lbt_channel_busy = False
-
-            if not can_tx:
-                if local_transmission:
-                    # Defer local TX until duty cycle allows instead of dropping
-                    deferred_delay = delay + wait_time
-                    logger.info(
-                        f"Duty-cycle limit: deferring local TX by {wait_time:.1f}s "
-                        f"(airtime={airtime_ms:.1f}ms)"
+                    extra_tx_tasks.append(
+                        await self.schedule_retransmit(
+                            extra_pkt,
+                            extra_delay,
+                            extra_airtime_ms,
+                            preferred_tx_radio_id=preferred_tx_radio_id,
+                        )
                     )
+
+                # Check duty-cycle before scheduling TX
+                airtime_ms = self.airtime_mgr.calculate_airtime(fwd_pkt.get_raw_length())
+
+                can_tx, wait_time = self.airtime_mgr.can_transmit(airtime_ms)
+
+                # LBT metadata (set after any TX path that awaits send)
+                tx_metadata = None
+                lbt_attempts = 0
+                lbt_backoff_delays_ms = None
+                lbt_channel_busy = False
+
+                if not can_tx:
+                    if local_transmission:
+                        # Defer local TX until duty cycle allows instead of dropping
+                        deferred_delay = delay + wait_time
+                        logger.info(
+                            f"Duty-cycle limit: deferring local TX by {wait_time:.1f}s "
+                            f"(airtime={airtime_ms:.1f}ms)"
+                        )
+                        tx_task = await self.schedule_retransmit(
+                            fwd_pkt,
+                            deferred_delay,
+                            airtime_ms,
+                            local_transmission=True,
+                            preferred_tx_radio_id=preferred_tx_radio_id,
+                        )
+                        try:
+                            tx_success = await tx_task
+                        except Exception as e:
+                            transmitted = False
+                            drop_reason = "TX failed (deferred)"
+                            logger.warning(f"Deferred local TX failed: {e}")
+                            raise
+                        if not tx_success:
+                            transmitted = False
+                            drop_reason = "TX failed (deferred)"
+                            self.dropped_count += 1
+                        else:
+                            self.forwarded_count += 1
+                            transmitted = True
+                        tx_metadata = getattr(fwd_pkt, "_tx_metadata", None)
+                        if tx_metadata:
+                            tx_radio_id = tx_metadata.get("radio_id") or tx_metadata.get(
+                                "tx_radio_id"
+                            )
+                            lbt_attempts = tx_metadata.get("lbt_attempts", 0)
+                            lbt_backoff_delays_ms = tx_metadata.get("lbt_backoff_delays_ms", [])
+                            lbt_channel_busy = tx_metadata.get("lbt_channel_busy", False)
+                            if lbt_attempts > 0:
+                                total_lbt_delay = sum(lbt_backoff_delays_ms)
+                                logger.info(
+                                    f"LBT: {lbt_attempts} attempts, "
+                                    f"{total_lbt_delay:.0f}ms delay, "
+                                    f"backoffs={lbt_backoff_delays_ms}"
+                                )
+                    else:
+                        logger.warning(
+                            f"Duty-cycle limit exceeded. Airtime={airtime_ms:.1f}ms, "
+                            f"wait={wait_time:.1f}s before retry"
+                        )
+                        self.dropped_count += 1
+                        drop_reason = DropReason.DUTY_CYCLE_LIMIT
+                else:
                     tx_task = await self.schedule_retransmit(
                         fwd_pkt,
-                        deferred_delay,
+                        delay,
                         airtime_ms,
-                        local_transmission=True,
+                        local_transmission=local_transmission,
                         preferred_tx_radio_id=preferred_tx_radio_id,
                     )
                     try:
                         tx_success = await tx_task
                     except Exception as e:
                         transmitted = False
-                        drop_reason = "TX failed (deferred)"
-                        logger.warning(f"Deferred local TX failed: {e}")
+                        drop_reason = "TX failed"
+                        logger.warning(f"Local TX failed: {e}")
                         raise
                     if not tx_success:
                         transmitted = False
-                        drop_reason = "TX failed (deferred)"
+                        drop_reason = "TX failed"
                         self.dropped_count += 1
                     else:
                         self.forwarded_count += 1
@@ -441,78 +500,48 @@ class RepeaterHandler(BaseHandler):
                         lbt_attempts = tx_metadata.get("lbt_attempts", 0)
                         lbt_backoff_delays_ms = tx_metadata.get("lbt_backoff_delays_ms", [])
                         lbt_channel_busy = tx_metadata.get("lbt_channel_busy", False)
+
                         if lbt_attempts > 0:
                             total_lbt_delay = sum(lbt_backoff_delays_ms)
                             logger.info(
-                                f"LBT: {lbt_attempts} attempts, "
-                                f"{total_lbt_delay:.0f}ms delay, "
+                                f"LBT: {lbt_attempts} attempts, {total_lbt_delay:.0f}ms delay, "
                                 f"backoffs={lbt_backoff_delays_ms}"
                             )
+
+                # Redundancy copies ride alongside the primary result: collect them
+                # without letting a failed extra change the primary outcome.
+                for extra_task in extra_tx_tasks:
+                    try:
+                        if await extra_task:
+                            self.forwarded_count += 1
+                    except Exception as e:
+                        logger.warning(f"Multi-ack redundancy TX failed: {e}")
+            else:
+                self.dropped_count += 1
+                # Determine drop reason
+                if local_transmission and not allow_local_tx:
+                    drop_reason = policy_reason or DropReason.NO_TX_MODE
+                elif not allow_forward:
+                    drop_reason = policy_reason or DropReason.REPEAT_DISABLED
                 else:
-                    logger.warning(
-                        f"Duty-cycle limit exceeded. Airtime={airtime_ms:.1f}ms, "
-                        f"wait={wait_time:.1f}s before retry"
+                    # Check if packet has a specific drop reason set by handlers
+                    drop_reason = processed_packet.drop_reason or self._get_drop_reason(
+                        processed_packet, packet_hash=pkt_hash_full
                     )
-                    self.dropped_count += 1
-                    drop_reason = DropReason.DUTY_CYCLE_LIMIT
-            else:
-                tx_task = await self.schedule_retransmit(
-                    fwd_pkt,
-                    delay,
-                    airtime_ms,
-                    local_transmission=local_transmission,
-                    preferred_tx_radio_id=preferred_tx_radio_id,
-                )
-                try:
-                    tx_success = await tx_task
-                except Exception as e:
-                    transmitted = False
-                    drop_reason = "TX failed"
-                    logger.warning(f"Local TX failed: {e}")
-                    raise
-                if not tx_success:
-                    transmitted = False
-                    drop_reason = "TX failed"
-                    self.dropped_count += 1
-                else:
-                    self.forwarded_count += 1
-                    transmitted = True
-                tx_metadata = getattr(fwd_pkt, "_tx_metadata", None)
-                if tx_metadata:
-                    tx_radio_id = tx_metadata.get("radio_id") or tx_metadata.get("tx_radio_id")
-                    lbt_attempts = tx_metadata.get("lbt_attempts", 0)
-                    lbt_backoff_delays_ms = tx_metadata.get("lbt_backoff_delays_ms", [])
-                    lbt_channel_busy = tx_metadata.get("lbt_channel_busy", False)
-
-                    if lbt_attempts > 0:
-                        total_lbt_delay = sum(lbt_backoff_delays_ms)
-                        logger.info(
-                            f"LBT: {lbt_attempts} attempts, {total_lbt_delay:.0f}ms delay, "
-                            f"backoffs={lbt_backoff_delays_ms}"
-                        )
-
-            # Redundancy copies ride alongside the primary result: collect them
-            # without letting a failed extra change the primary outcome.
-            for extra_task in extra_tx_tasks:
-                try:
-                    if await extra_task:
-                        self.forwarded_count += 1
-                except Exception as e:
-                    logger.warning(f"Multi-ack redundancy TX failed: {e}")
-        else:
-            self.dropped_count += 1
-            # Determine drop reason
-            if local_transmission and not allow_local_tx:
-                drop_reason = policy_reason or DropReason.NO_TX_MODE
-            elif not allow_forward:
-                drop_reason = policy_reason or DropReason.REPEAT_DISABLED
-            else:
-                # Check if packet has a specific drop reason set by handlers
-                drop_reason = processed_packet.drop_reason or self._get_drop_reason(
-                    processed_packet, packet_hash=pkt_hash_full
-                )
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"Packet not forwarded: {drop_reason}")
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(f"Packet not forwarded: {drop_reason}")
+        finally:
+            # Release the seen-table entry when the forward decision did not
+            # reach the air (duty cycle, radio error, a modem refusing the
+            # channel for the whole LBT budget). The entry exists to suppress
+            # our own echo; holding it for a packet we never relayed would
+            # silently drop every later copy of it — including a neighbour's
+            # rebroadcast, the only way this node could still relay it — until
+            # the cache TTL expires. Only an entry reserved by THIS call is
+            # released: a genuine duplicate yields no forward decision, so the
+            # entry left by the transmission that did happen stays put.
+            if seen_key is not None and not transmitted:
+                self.unmark_seen(seen_key)
 
         # Extract packet type and route from header
         if not hasattr(packet, "header") or packet.header is None:
@@ -959,13 +988,23 @@ class RepeaterHandler(BaseHandler):
         pkt_hash = packet_hash or packet.calculate_packet_hash().hex().upper()
         return pkt_hash in self.seen_packets
 
-    def mark_seen(self, packet: Packet, packet_hash: Optional[str] = None):
-
+    def mark_seen(self, packet: Packet, packet_hash: Optional[str] = None) -> str:
+        """Record the packet as seen and return the key used."""
         pkt_hash = packet_hash or packet.calculate_packet_hash().hex().upper()
         self.seen_packets[pkt_hash] = time.time()
 
         if len(self.seen_packets) > self.max_cache_size:
             self.seen_packets.popitem(last=False)
+        return pkt_hash
+
+    def unmark_seen(self, packet_hash: str) -> None:
+        """Release a seen-table entry reserved by a forward decision.
+
+        Only ever call this for an entry marked by the same packet handling that
+        then failed to transmit: releasing an entry marked by an earlier, real
+        transmission would let its echo be relayed a second time.
+        """
+        self.seen_packets.pop(packet_hash, None)
 
     def validate_packet(self, packet: Packet) -> Tuple[bool, str]:
 
@@ -1315,7 +1354,7 @@ class RepeaterHandler(BaseHandler):
         if self.is_duplicate(packet, packet_hash=seen_key):
             packet.drop_reason = DropReason.DUPLICATE
             return None
-        self.mark_seen(packet, packet_hash=seen_key)
+        seen_key = self.mark_seen(packet, packet_hash=seen_key)
 
         # Rebuild the received wrapper as the plain DIRECT ACK MeshCore would emit:
         # drop the multipart header byte and force the ACK payload/route type, then
@@ -1330,7 +1369,7 @@ class RepeaterHandler(BaseHandler):
         extras, delay_ms = self._multi_ack_extras(
             packet, float((remaining + 1) * self.MULTIPART_ACK_SPACING_MS), snr
         )
-        return ForwardResult(packet, delay_ms / 1000.0, extras)
+        return ForwardResult(packet, delay_ms / 1000.0, extras, seen_key=seen_key)
 
     def _multi_ack_extras(
         self, ack_packet: Packet, base_delay_ms: float, snr: float
@@ -1404,7 +1443,7 @@ class RepeaterHandler(BaseHandler):
         if self.is_duplicate(packet, packet_hash=packet_hash):
             packet.drop_reason = DropReason.DUPLICATE
             return None
-        self.mark_seen(packet, packet_hash=packet_hash)
+        seen_key = self.mark_seen(packet, packet_hash=packet_hash)
 
         packet.header = (PAYLOAD_TYPE_ACK << PH_TYPE_SHIFT) | ROUTE_TYPE_DIRECT
         packet.transport_codes = [0, 0]
@@ -1412,7 +1451,7 @@ class RepeaterHandler(BaseHandler):
         packet.path_len = PathUtils.encode_path_len(hash_size, hop_count - 1)
 
         extras, delay_ms = self._multi_ack_extras(packet, 0.0, snr)
-        return ForwardResult(packet, delay_ms / 1000.0, extras)
+        return ForwardResult(packet, delay_ms / 1000.0, extras, seen_key=seen_key)
 
     @staticmethod
     def calculate_packet_score(snr: float, packet_len: int, spreading_factor: int = 8) -> float:
@@ -1495,19 +1534,23 @@ class RepeaterHandler(BaseHandler):
         ):
             return self.forward_routed_ack(packet, snr, packet_hash=packet_hash)
 
+        # ``packet_hash`` is the key flood_forward / direct_forward mark with, so
+        # it is what the caller must release if the transmit never happens. Do
+        # not recompute it here: a TRACE packet folds path_len into its hash, and
+        # the forward has already appended this node to the path by then.
         if route_type == ROUTE_TYPE_FLOOD or route_type == ROUTE_TYPE_TRANSPORT_FLOOD:
             fwd_pkt = self.flood_forward(packet, packet_hash=packet_hash)
             if fwd_pkt is None:
                 return None
             delay = self._calculate_tx_delay(fwd_pkt, snr)
-            return fwd_pkt, delay
+            return ForwardResult(fwd_pkt, delay, seen_key=packet_hash)
 
         elif route_type == ROUTE_TYPE_DIRECT or route_type == ROUTE_TYPE_TRANSPORT_DIRECT:
             fwd_pkt = self.direct_forward(packet, packet_hash=packet_hash)
             if fwd_pkt is None:
                 return None
             delay = self._calculate_tx_delay(fwd_pkt, snr)
-            return fwd_pkt, delay
+            return ForwardResult(fwd_pkt, delay, seen_key=packet_hash)
 
         else:
             packet.drop_reason = f"Unknown route type: {route_type}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2935,3 +2935,166 @@ class TestEngineRecordAndCleanupHelpers:
         handler.cleanup()
 
         fake_task.cancel.assert_called_once()
+
+
+# ===================================================================
+# 13. Seen-table reservation lifetime
+# ===================================================================
+
+
+class TestSeenTableRollback:
+    """The seen-table entry must last exactly as long as the transmission did.
+
+    A forward decision reserves an entry in ``seen_packets`` so the copy
+    echoing back off a neighbour is suppressed.  That reservation is only
+    legitimate once the packet is on the air: if the transmit never happens,
+    holding the entry makes this node drop every later copy of a packet it
+    never relayed — including the neighbour rebroadcast that is its last
+    chance to relay it.
+
+    These assert on observable behaviour — how often the dispatcher is asked
+    to send — rather than on ``seen_packets``, so they keep their meaning if
+    the cache is reworked.
+    """
+
+    @staticmethod
+    async def _deliver(handler, packet):
+        """Feed one received packet through the handler, delays collapsed."""
+        with (
+            patch.object(handler, "_calculate_tx_delay", return_value=0.0),
+            patch("repeater.engine.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await handler(
+                _inject_from_wire(packet),
+                {"snr": 3.0, "rssi": -80},
+                local_transmission=False,
+            )
+
+    @staticmethod
+    def _ready(handler):
+        handler.airtime_mgr.calculate_airtime = MagicMock(return_value=20.0)
+        handler.airtime_mgr.can_transmit = MagicMock(return_value=(True, 0.0))
+        handler.airtime_mgr.record_tx = MagicMock()
+        handler.airtime_mgr.record_rx = MagicMock()
+        handler.dispatcher.send_packet = AsyncMock(return_value=True)
+
+    # ── the transmit never happened → the packet stays relayable ──────
+
+    @staticmethod
+    def _tx_returns_false(handler):
+        handler.dispatcher.send_packet = AsyncMock(return_value=False)
+
+    @staticmethod
+    def _tx_raises(handler):
+        handler.dispatcher.send_packet = AsyncMock(side_effect=RuntimeError("radio gone"))
+
+    @staticmethod
+    def _duty_cycle_refuses_upfront(handler):
+        handler.airtime_mgr.can_transmit = MagicMock(return_value=(False, 12.0))
+
+    @staticmethod
+    def _duty_cycle_refuses_at_tx_time(handler):
+        """Admitted when scheduled, refused once the TX lock is held."""
+        handler.airtime_mgr.can_transmit = MagicMock(side_effect=[(True, 0.0), (False, 12.0)])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "make_it_fail",
+        [
+            "_tx_returns_false",
+            "_tx_raises",
+            "_duty_cycle_refuses_upfront",
+            "_duty_cycle_refuses_at_tx_time",
+        ],
+    )
+    async def test_forward_that_never_reached_the_air_is_relayable_again(
+        self, handler, make_it_fail
+    ):
+        self._ready(handler)
+        getattr(self, make_it_fail)(handler)
+
+        try:
+            await self._deliver(handler, _make_flood_packet(payload=b"\x11\x22\x33\x44"))
+        except RuntimeError:
+            pass  # the raising variant propagates; the release must happen anyway
+
+        assert handler.seen_packets == {}, "reservation left behind for a packet never sent"
+
+        # The neighbour's rebroadcast must be forwarded, not swallowed as a dupe.
+        self._ready(handler)
+        await self._deliver(handler, _make_flood_packet(payload=b"\x11\x22\x33\x44"))
+
+        assert handler.dispatcher.send_packet.await_count == 1
+
+    # ── the transmit happened → the echo stays suppressed ─────────────
+
+    @pytest.mark.asyncio
+    async def test_transmitted_packet_suppresses_its_echo(self, handler):
+        self._ready(handler)
+
+        await self._deliver(handler, _make_flood_packet(payload=b"\x55\x66\x77\x88"))
+        await self._deliver(handler, _make_flood_packet(payload=b"\x55\x66\x77\x88"))
+
+        assert handler.dispatcher.send_packet.await_count == 1
+        assert handler.forwarded_count == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_does_not_release_the_reservation_of_the_real_send(self, handler):
+        """The trap: a duplicate is also "not transmitted this time".
+
+        Releasing on that basis would let the third copy be relayed again,
+        turning every echo into a fresh transmission — dedupe would be gone
+        while every other test here still passed.
+        """
+        self._ready(handler)
+        payload = b"\x99\xaa\xbb\xcc"
+
+        await self._deliver(handler, _make_flood_packet(payload=payload))  # relayed
+        await self._deliver(handler, _make_flood_packet(payload=payload))  # duplicate
+        await self._deliver(handler, _make_flood_packet(payload=payload))  # still a duplicate
+
+        assert handler.dispatcher.send_packet.await_count == 1
+        assert handler.seen_packets, "the transmitted packet lost its reservation"
+
+    @pytest.mark.asyncio
+    async def test_failed_send_does_not_release_an_unrelated_reservation(self, handler):
+        """Releasing must be keyed, not a blanket clear of recent state."""
+        self._ready(handler)
+        await self._deliver(handler, _make_flood_packet(payload=b"\x01\x01\x01\x01"))
+        kept = dict(handler.seen_packets)
+
+        self._tx_returns_false(handler)
+        await self._deliver(handler, _make_flood_packet(payload=b"\x02\x02\x02\x02"))
+
+        assert handler.seen_packets == kept
+
+    # ── every forward branch must report the key it marked ────────────
+
+    @pytest.mark.parametrize(
+        "make_packet",
+        [
+            lambda: _make_flood_packet(payload=b"\x31\x32\x33\x34"),
+            lambda: _make_direct_packet(payload=b"\x41\x42\x43\x44"),
+            lambda: _make_direct_ack_packet(path=bytes([LOCAL_HASH, 0xCC])),
+            lambda: _make_multipart_ack_packet(path=bytes([LOCAL_HASH, 0xCC])),
+        ],
+        ids=["flood", "direct", "routed_ack", "multipart_ack"],
+    )
+    def test_every_forward_branch_reports_the_key_it_marked(self, handler, make_packet):
+        """Structural counterpart to the behavioural tests above.
+
+        A branch that marks the table but returns no ``seen_key`` leaks its
+        reservation on every failed send, and no behavioural test would exist
+        yet for a newly added branch.  The multipart branch marks a recomputed
+        key of its own, so the incoming packet hash cannot be assumed.
+        """
+        packet = _inject_from_wire(make_packet())
+        packet_hash = packet.calculate_packet_hash().hex().upper()
+
+        result = handler.process_packet(packet, snr=3.0, packet_hash=packet_hash)
+
+        assert result is not None, "packet was not forwarded; test setup no longer valid"
+        seen_key = getattr(result, "seen_key", None)
+        assert seen_key is not None, "branch marked the table without reporting a key"
+        assert seen_key in handler.seen_packets, "reported key is not the one marked"
+        assert set(handler.seen_packets) == {seen_key}


### PR DESCRIPTION
## Problem

A forward decision reserves an entry in `seen_packets` before the packet reaches the dispatcher, so the copy echoing back off a neighbour is suppressed. The placement mirrors MeshCore, which marks on receive (`Mesh::onRecvPacket`, e.g. `Mesh.cpp:123-124`) and again in `sendFlood`/`sendDirect` — *"mark this packet as already sent in case it is rebroadcast back to us"*.

**The reservation was never released when the transmit did not happen.** Any of these left it behind:

| path | file:line |
|---|---|
| duty-cycle gate refuses the packet when it is scheduled | `engine.py` — advisory `can_transmit` before `schedule_retransmit` |
| duty-cycle gate refuses again at TX time, under the lock | `engine.py` — *"Packet dropped at TX time: duty-cycle exceeded"* |
| `dispatcher.send_packet` reports failure — radio error, or a modem refusing the channel for the whole LBT budget (`usb_radio`/`tcp_radio` return `None`, which the dispatcher reads as failure) | `dispatcher.py` |
| an exception propagates out of the send | `engine.py` — the relayed branch re-raises |

The node then dropped **every later copy of a packet it had never relayed**, for up to `cache_ttl` (default 3600 s), including the neighbour rebroadcast that was its only remaining chance to relay it. There is no retry at this layer, so the packet was simply lost.

Second-order effect, which is why this is easy to miss in production: the leftover entry also makes the packet count as a duplicate in the statistics —

```python
is_dupe = pkt_hash_full in self.seen_packets and not transmitted
...
self.flood_dup_count += 1
```

so a transmit failure is reported as a flood/direct duplicate. The loss is invisible in the very metrics that would have shown it.

## Field evidence

Captured on a live repeater. One GRP_TXT flood packet, 131 B, three receptions — the UI groups them because the node itself classified two of them as duplicates:

![A TX-failed packet, then suppressed as a duplicate twice](https://raw.githubusercontent.com/npdgm/openhop_repeater/d2cf6ea40dceb4754d69448849db1edb7af01304/evidence/tx-failed-as-duplicate.png)

Oldest at the bottom:

| time | how it arrived | RSSI / SNR / score | outcome |
|---|---|---|---|
| 23:27:06 | direct from AB1D | −88 dBm / 8.5 dB / 0.85 | **Dropped — `TX failed`** (5.00 s TX delay) |
| 23:27:08 | 1 hop, AB1D → 882F | **−34 dBm / 13.5 dB / 1.00** | **Dropped — `Duplicate`** |
| 23:27:34 | 9 hops | −106 dBm / −3.0 dB / 0.27 | **Dropped — `Duplicate`** |

The node never put this packet on the air. Two seconds later a neighbour offered it back at −34 dBm with a **perfect 1.00 score** — the best possible copy to relay — and it was discarded as a duplicate of a transmission that never happened. The 9-hop copy 26 s later met the same fate.

Note the labels on the right: the reception that failed to transmit is itself listed as *Duplicate #2* inside the duplicate group. That is the statistics side effect described above — the packet loss is not merely invisible, it is filed under the counter that says everything is working.

## Change

- Every forward branch reports the key it marked, via a new `ForwardResult.seen_key`. The key must be **reported, not recomputed**: a TRACE packet folds `path_len` into its hash (`Packet.calculate_packet_hash`), and by then the forward has already appended this node to the path.
- `__call__` releases that key from a `finally`, so **every way the block can end — drop, failure or exception — goes through one release point**, and a future failure path cannot forget it.
- Only an entry reserved by the same call is released. A genuine duplicate yields no forward decision (`is_duplicate` returns early), so the entry left by the transmission that did happen stays put.
- `mark_seen` now returns the key it used; `unmark_seen` is its counterpart.

The bulk of the `engine.py` diff is re-indentation under the new `try` — the behavioural change is the `finally` block and the `seen_key` plumbing.

### Trade-off

If a transmit actually reached the air but was *reported* as failed (a modem whose `TX_DONE` is lost), the entry is released and a later echo may be relayed once more. That costs one airtime; every other node drops it as a duplicate. The alternative — the current behaviour — permanently drops a packet that was never sent. The asymmetry favours releasing.

## Tests

Eleven tests in `TestSeenTableRollback` (`tests/test_engine.py`), written to fail on a wrong fix rather than to cover lines. They assert on observable behaviour — how often the dispatcher is asked to send — rather than on `seen_packets`, so they keep their meaning if the cache is reworked.

- **4 × `test_forward_that_never_reached_the_air_is_relayable_again`** — parametrised over the four failure paths above; each asserts no entry is left behind *and* that a later copy is forwarded.
- **`test_transmitted_packet_suppresses_its_echo`** — the mirror: dedupe still works.
- **`test_duplicate_does_not_release_the_reservation_of_the_real_send`** — the trap. A naive "release whenever the packet was not transmitted this time" implementation passes **10 of the 11 tests** and is caught only by this one: it would release the entry made by the successful send when the duplicate arrives, so the third copy would be relayed again and dedupe would be silently gone.
- **`test_failed_send_does_not_release_an_unrelated_reservation`** — the release is keyed, not a blanket clear.
- **4 × `test_every_forward_branch_reports_the_key_it_marked`** — flood, direct, routed ACK, multipart ACK. Structural counterpart: a branch that marks the table without reporting a key would leak on every failed send, and a newly added branch has no behavioural test yet. The multipart branch marks a *recomputed* key of its own, so the incoming packet hash cannot be assumed.

Verified in both directions: **9 of 11 fail on `dev`**, and the 2 that pass there are exactly the two guarding against over-correction.

## Test plan

- [x] `pytest tests/test_engine.py` — 388 passed
- [x] Full suite — 1470 passed; the single failure (`test_text_helper_real_crypto_consume_vs_collision_forward`) fails identically on `dev` and is unrelated
- [x] `ruff check` parity with `dev` (identical findings), `ruff format --check` clean
- [ ] Not covered: the same reservation exists one layer down in `openhop_core` (`packet_filter.track_packet` before `radio.send`, 30 s window) — fixed separately

