### PR TITLE
fix(engine): hold relayed packets over the airtime budget instead of dropping

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -614,6 +614,15 @@ duty_cycle:
   # Maximum airtime per minute in milliseconds
   max_airtime_per_minute: 3600
 
+  # How many relayed packets may wait for the airtime budget at the same time.
+  # Over budget, a relay is held back until the budget admits it instead of
+  # being dropped (firmware behaviour: Dispatcher::checkSend leaves the packet
+  # queued and simply reschedules).  Each waiting relay occupies one router
+  # in-flight slot, so this stays well under that cap; further relays arriving
+  # while every slot is taken are dropped, as the firmware drops once its own
+  # send queue is full.  Set to 0 to drop immediately instead of deferring.
+  max_deferred_relays: 8
+
 # Storage Configuration
 storage:
   # Directory for persistent storage files (SQLite, RRD).

--- a/repeater/engine.py
+++ b/repeater/engine.py
@@ -149,6 +149,16 @@ class RepeaterHandler(BaseHandler):
         self.use_score_for_tx = config.get("repeater", {}).get("use_score_for_tx", False)
         self.score_threshold = config.get("repeater", {}).get("score_threshold", 0.3)
         self.multi_acks = self._normalize_multi_acks(config)
+        # Relayed packets held back until the airtime budget admits them, rather
+        # than dropped on the spot.  Bounded like MeshCore bounds its outbound
+        # queue (StaticPoolPacketManager(32) in the repeater firmware, dropping
+        # once full): a deferred relay occupies one of PacketRouter's in-flight
+        # slots for the whole wait, and those slots also carry packets meant for
+        # local consumption, so the cap stays well under _max_in_flight (30).
+        self.max_deferred_relays = max(
+            0, int(config.get("duty_cycle", {}).get("max_deferred_relays", 8))
+        )
+        self._deferred_relays = 0
         self.max_flood_hops = config.get("repeater", {}).get("max_flood_hops", 64)
         self.send_advert_interval_hours = config.get("repeater", {}).get(
             "send_advert_interval_hours", 10
@@ -406,28 +416,42 @@ class RepeaterHandler(BaseHandler):
             lbt_backoff_delays_ms = None
             lbt_channel_busy = False
 
+            defer_relay = (
+                not local_transmission
+                and not can_tx
+                and self._deferred_relays < self.max_deferred_relays
+            )
             if not can_tx:
-                if local_transmission:
-                    # Defer local TX until duty cycle allows instead of dropping
+                if local_transmission or defer_relay:
+                    # Hold the packet until the airtime budget admits it instead
+                    # of dropping it: MeshCore's checkSend() reschedules its next
+                    # TX and leaves the packet queued, so congestion costs latency
+                    # rather than the packet.
                     deferred_delay = delay + wait_time
+                    kind = "local" if local_transmission else "relayed"
                     logger.info(
-                        f"Duty-cycle limit: deferring local TX by {wait_time:.1f}s "
+                        f"Duty-cycle limit: deferring {kind} TX by {wait_time:.1f}s "
                         f"(airtime={airtime_ms:.1f}ms)"
                     )
-                    tx_task = await self.schedule_retransmit(
-                        fwd_pkt,
-                        deferred_delay,
-                        airtime_ms,
-                        local_transmission=True,
-                        preferred_tx_radio_id=preferred_tx_radio_id,
-                    )
+                    if defer_relay:
+                        self._deferred_relays += 1
                     try:
+                        tx_task = await self.schedule_retransmit(
+                            fwd_pkt,
+                            deferred_delay,
+                            airtime_ms,
+                            local_transmission=local_transmission,
+                            preferred_tx_radio_id=preferred_tx_radio_id,
+                        )
                         tx_success = await tx_task
                     except Exception as e:
                         transmitted = False
                         drop_reason = "TX failed (deferred)"
-                        logger.warning(f"Deferred local TX failed: {e}")
+                        logger.warning(f"Deferred {kind} TX failed: {e}")
                         raise
+                    finally:
+                        if defer_relay:
+                            self._deferred_relays -= 1
                     if not tx_success:
                         transmitted = False
                         drop_reason = "TX failed (deferred)"
@@ -449,9 +473,13 @@ class RepeaterHandler(BaseHandler):
                                 f"backoffs={lbt_backoff_delays_ms}"
                             )
                 else:
+                    # Nothing left to hold it in: the deferral slots are full,
+                    # the analogue of MeshCore dropping in queueOutbound() once
+                    # its send queue is full.
                     logger.warning(
-                        f"Duty-cycle limit exceeded. Airtime={airtime_ms:.1f}ms, "
-                        f"wait={wait_time:.1f}s before retry"
+                        f"Duty-cycle limit exceeded, no deferral slot free "
+                        f"({self._deferred_relays}/{self.max_deferred_relays}). "
+                        f"Airtime={airtime_ms:.1f}ms, wait={wait_time:.1f}s"
                     )
                     self.dropped_count += 1
                     drop_reason = DropReason.DUTY_CYCLE_LIMIT

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2668,7 +2668,9 @@ class TestEngineTransmissionAndBackgroundLifecycle:
 
     @pytest.mark.asyncio
     async def test_non_local_drop_when_duty_cycle_blocked(self, handler):
+        """With no deferral slot free, an over-budget relay is still dropped."""
         pkt = _make_flood_packet(payload=b"\x31\x32")
+        handler.max_deferred_relays = 0
         handler.airtime_mgr.calculate_airtime = MagicMock(return_value=80.0)
         handler.airtime_mgr.can_transmit = MagicMock(return_value=(False, 1.25))
         handler.process_packet = MagicMock(return_value=(pkt, 0.1))
@@ -2935,3 +2937,155 @@ class TestEngineRecordAndCleanupHelpers:
         handler.cleanup()
 
         fake_task.cancel.assert_called_once()
+
+
+# ===================================================================
+# 14. Duty-cycle deferral of relayed packets
+# ===================================================================
+
+
+class TestRelayedDutyCycleDeferral:
+    """Over budget, a relay is held back rather than thrown away.
+
+    Firmware parity: ``Dispatcher::checkSend`` reschedules its next TX and
+    leaves the packet queued when the airtime budget is short, so congestion
+    costs latency, not the packet.  The number of relays waiting at once is
+    capped, mirroring the firmware dropping in ``queueOutbound`` once its send
+    queue is full — here the bound also protects the router's in-flight slots.
+    """
+
+    @staticmethod
+    def _ready(handler, *, deferrals=8):
+        handler.max_deferred_relays = deferrals
+        handler._deferred_relays = 0
+        handler.airtime_mgr.calculate_airtime = MagicMock(return_value=20.0)
+        handler.airtime_mgr.record_tx = MagicMock()
+        handler.airtime_mgr.record_rx = MagicMock()
+        handler.dispatcher.send_packet = AsyncMock(return_value=True)
+
+    @staticmethod
+    async def _deliver(handler, packet):
+        with (
+            patch.object(handler, "_calculate_tx_delay", return_value=0.0),
+            patch("repeater.engine.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await handler(
+                _inject_from_wire(packet),
+                {"snr": 3.0, "rssi": -80},
+                local_transmission=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_relay_over_budget_is_deferred_then_sent(self, handler):
+        """Refused upfront, admitted once the budget frees: it must go out."""
+        self._ready(handler)
+        handler.airtime_mgr.can_transmit = MagicMock(side_effect=[(False, 7.5), (True, 0.0)])
+
+        await self._deliver(handler, _make_flood_packet(payload=b"\x21\x22\x23\x24"))
+
+        assert handler.dispatcher.send_packet.await_count == 1
+        assert handler.forwarded_count == 1
+        assert handler.dropped_count == 0
+
+    @pytest.mark.asyncio
+    async def test_deferred_relay_waits_for_the_budget(self, handler):
+        """The wait is the delay the budget asked for, not an immediate retry."""
+        self._ready(handler)
+        handler.airtime_mgr.can_transmit = MagicMock(side_effect=[(False, 7.5), (True, 0.0)])
+        scheduled = []
+
+        async def _capture(pkt, delay, *args, **kwargs):
+            scheduled.append(delay)
+            task = asyncio.get_running_loop().create_future()
+            task.set_result(True)
+            return task
+
+        with (
+            patch.object(handler, "_calculate_tx_delay", return_value=0.0),
+            patch.object(handler, "schedule_retransmit", side_effect=_capture),
+        ):
+            await handler(
+                _inject_from_wire(_make_flood_packet(payload=b"\x25\x26\x27\x28")),
+                {"snr": 3.0, "rssi": -80},
+                local_transmission=False,
+            )
+
+        assert scheduled == [7.5]
+
+    @pytest.mark.asyncio
+    async def test_relay_still_over_budget_at_tx_time_is_dropped_not_retried(self, handler):
+        """One deferral, not a loop: the authoritative gate still decides."""
+        self._ready(handler)
+        handler.airtime_mgr.can_transmit = MagicMock(return_value=(False, 7.5))
+
+        await self._deliver(handler, _make_flood_packet(payload=b"\x29\x2a\x2b\x2c"))
+
+        assert handler.dispatcher.send_packet.await_count == 0
+        assert handler.forwarded_count == 0
+
+    @pytest.mark.asyncio
+    async def test_deferral_slots_are_released_after_the_wait(self, handler):
+        """A leaked slot would silently turn deferral back into dropping."""
+        self._ready(handler)
+        handler.airtime_mgr.can_transmit = MagicMock(
+            side_effect=[(False, 1.0), (True, 0.0), (False, 1.0), (True, 0.0)]
+        )
+
+        await self._deliver(handler, _make_flood_packet(payload=b"\x31\x31\x31\x31"))
+        await self._deliver(handler, _make_flood_packet(payload=b"\x32\x32\x32\x32"))
+
+        assert handler._deferred_relays == 0
+        assert handler.dispatcher.send_packet.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_slot_is_released_even_when_the_deferred_send_raises(self, handler):
+        self._ready(handler)
+        handler.airtime_mgr.can_transmit = MagicMock(side_effect=[(False, 1.0), (True, 0.0)])
+        handler.dispatcher.send_packet = AsyncMock(side_effect=RuntimeError("radio gone"))
+
+        with pytest.raises(RuntimeError):
+            await self._deliver(handler, _make_flood_packet(payload=b"\x33\x33\x33\x33"))
+
+        assert handler._deferred_relays == 0
+
+    @pytest.mark.asyncio
+    async def test_relay_is_dropped_once_every_deferral_slot_is_taken(self, handler):
+        """The bound must actually bite, or a burst outlives the router."""
+        self._ready(handler, deferrals=2)
+        handler._deferred_relays = 2  # both slots already occupied
+        handler.airtime_mgr.can_transmit = MagicMock(return_value=(False, 7.5))
+
+        await self._deliver(handler, _make_flood_packet(payload=b"\x41\x42\x43\x44"))
+
+        assert handler.dispatcher.send_packet.await_count == 0
+        assert handler.dropped_count == 1
+
+    @pytest.mark.asyncio
+    async def test_deferral_can_be_switched_off(self, handler):
+        """max_deferred_relays = 0 keeps the previous drop-on-congestion behaviour."""
+        self._ready(handler, deferrals=0)
+        handler.airtime_mgr.can_transmit = MagicMock(return_value=(False, 7.5))
+
+        await self._deliver(handler, _make_flood_packet(payload=b"\x51\x52\x53\x54"))
+
+        assert handler.dispatcher.send_packet.await_count == 0
+        assert handler.dropped_count == 1
+
+    @pytest.mark.asyncio
+    async def test_local_transmission_never_consumes_a_relay_slot(self, handler):
+        """Local TX had its own deferral before this change and keeps it."""
+        self._ready(handler, deferrals=0)  # relays may not defer at all
+        handler.airtime_mgr.can_transmit = MagicMock(side_effect=[(False, 1.0), (True, 0.0)])
+
+        with (
+            patch.object(handler, "_calculate_tx_delay", return_value=0.0),
+            patch("repeater.engine.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await handler(
+                _inject_from_wire(_make_flood_packet(payload=b"\x61\x62\x63\x64")),
+                {"snr": 3.0, "rssi": -80},
+                local_transmission=True,
+            )
+
+        assert handler.dispatcher.send_packet.await_count == 1
+        assert handler._deferred_relays == 0


### PR DESCRIPTION
## Problem

A relayed packet that arrives while the duty-cycle budget is spent is thrown away on the spot:

```python
else:
    logger.warning(f"Duty-cycle limit exceeded. Airtime={airtime_ms:.1f}ms, wait={wait_time:.1f}s before retry")
    self.dropped_count += 1
    drop_reason = DropReason.DUTY_CYCLE_LIMIT
```

The log even says *"before retry"* — but there is no retry. Locally originated traffic sitting three lines above gets the opposite treatment: it is scheduled for `delay + wait_time` and goes out when the budget frees.

So the packet most likely to be dropped is the one another node is relying on this repeater to carry, and it is dropped precisely when the mesh is busy — when a relay matters most. `can_transmit()` returns the time until the oldest airtime entry leaves the 60 s window, so the wait is usually a few seconds.

## Firmware parity

MeshCore does not drop here either. `Dispatcher::checkSend()` checks the budget first and, when it is short, computes how long is needed, pushes `next_tx_time` out by that much and returns — **with the packet still in the outbound queue**:

```cpp
if (tx_budget_ms < est_airtime / MIN_TX_BUDGET_AIRTIME_DIV) {
    float duty_cycle = 1.0f / (1.0f + getAirtimeBudgetFactor());
    unsigned long needed = est_airtime / MIN_TX_BUDGET_AIRTIME_DIV - tx_budget_ms;
    next_tx_time = futureMillis((unsigned long)(needed / duty_cycle));
    return;
}
```

Congestion costs latency there, not the packet. Dropping is reserved for the case where there is nowhere left to put it — `queueOutbound()` failing to add, logging *"send queue full, dropping packet"*.

## Change

Relays take the same deferral path local traffic already uses: scheduled for the wait the airtime manager asked for, with `local_transmission` passed through rather than forced to `True` (so relays keep their no-retry semantics).

**It stays one deferral, not a retry loop.** The authoritative duty-cycle gate under the TX lock still has the final say, so a budget that has not recovered by the time the packet wakes drops it exactly as before.

**The wait is bounded in slots.** A waiting relay holds one of `PacketRouter`'s in-flight slots for its whole wait, and that pool also carries packets meant for local consumption — once its cap of 30 is reached the router drops *received* packets outright. Deferrals are therefore capped at `duty_cycle.max_deferred_relays` (default 8, comfortably clear of 30). Relays arriving with every slot taken are dropped exactly as they are today; that is the firmware's full-queue case. Setting the cap to `0` restores drop-on-congestion behaviour with no other change.

The firmware bounds the same thing by construction — its repeater build allocates `StaticPoolPacketManager(32)`, so its outbound queue cannot exceed that pool either.

## Tests

Eight tests in `TestRelayedDutyCycleDeferral`, split between the new behaviour and the bounds that keep it safe:

| test | pins |
|---|---|
| `test_relay_over_budget_is_deferred_then_sent` | refused upfront, admitted at TX time → the packet goes out, nothing dropped |
| `test_deferred_relay_waits_for_the_budget` | it waits *the wait the budget asked for* (7.5 s), not an immediate retry |
| `test_relay_still_over_budget_at_tx_time_is_dropped_not_retried` | one deferral only — no loop |
| `test_deferral_slots_are_released_after_the_wait` | a leaked slot would silently turn deferral back into dropping |
| `test_slot_is_released_even_when_the_deferred_send_raises` | same, on the exception path |
| `test_relay_is_dropped_once_every_deferral_slot_is_taken` | the bound actually bites |
| `test_deferral_can_be_switched_off` | `max_deferred_relays = 0` restores today's behaviour |
| `test_local_transmission_never_consumes_a_relay_slot` | local TX keeps its own deferral and does not compete for slots |

The four behavioural tests **fail on `dev`**; the four guarding the bounds pass there too, by design — they exist to catch an over-correction, not to prove the feature.

`test_non_local_drop_when_duty_cycle_blocked` is updated: it now sets `max_deferred_relays = 0` and keeps asserting the drop, so the old path stays covered rather than deleted.

## Test plan

- [x] `pytest tests/test_engine.py` — 385 passed
- [x] Full suite — 1467 passed; the single failure (`test_text_helper_real_crypto_consume_vs_collision_forward`) fails identically on `dev` and is unrelated
- [x] `ruff check` parity with `dev` (identical findings), `ruff format --check` clean, `config.yaml.example` parses
- [ ] Not verified on air: worth watching `Duty-cycle limit: deferring relayed TX by …` against `no deferral slot free` on a busy site to see whether 8 is the right default

## Out of scope

The LBT/channel-busy side of congestion is a different mechanism (the radio drivers bound it in time and force the transmit at the cap), and is untouched here.
