### PR TITLE
fix(api): persist the mode selected through set_mode

### DIFF
--- a/repeater/web/api_endpoints.py
+++ b/repeater/web/api_endpoints.py
@@ -1983,8 +1983,18 @@ class APIEndpoints:
             if "repeater" not in self.config:
                 self.config["repeater"] = {}
             self.config["repeater"]["mode"] = new_mode
+
+            # The engine reads the mode live from the shared config dict;
+            # update_and_save writes it to disk so the choice survives a
+            # restart.
+            result = self.config_manager.update_and_save(
+                updates={}, live_update=True, live_update_sections=["repeater"]
+            )
+            if not result.get("saved", False):
+                return self._error(result.get("error", "Failed to save configuration to file"))
+
             logger.info(f"Mode changed to: {new_mode}")
-            return {"success": True, "mode": new_mode}
+            return {"success": True, "mode": new_mode, "persisted": True}
         except cherrypy.HTTPError:
             # Re-raise HTTP errors (like 405 Method Not Allowed) without logging
             raise

--- a/tests/test_api_endpoints_core_coverage.py
+++ b/tests/test_api_endpoints_core_coverage.py
@@ -1726,15 +1726,34 @@ def test_set_mode_and_set_duty_cycle_paths(cherrypy_ctx):
     invalid = api.set_mode()
     assert invalid["success"] is False
 
+    api.config_manager.update_and_save.return_value = {"saved": True}
     request.json = {"mode": "monitor"}
     ok = api.set_mode()
-    assert ok == {"success": True, "mode": "monitor"}
+    assert ok == {"success": True, "mode": "monitor", "persisted": True}
     assert api.config["repeater"]["mode"] == "monitor"
+    api.config_manager.update_and_save.assert_called_once_with(
+        updates={}, live_update=True, live_update_sections=["repeater"]
+    )
 
     request.json = {"enabled": False}
     duty = api.set_duty_cycle()
     assert duty == {"success": True, "enabled": False}
     assert api.config["duty_cycle"]["enforcement_enabled"] is False
+
+
+def test_set_mode_save_failure_reports_error(cherrypy_ctx):
+    request, _ = cherrypy_ctx
+    api = _make_api({"repeater": {}})
+    api.config_manager.update_and_save.return_value = {"saved": False, "error": "disk full"}
+
+    request.method = "POST"
+    request.json = {"mode": "no_tx"}
+    resp = api.set_mode()
+    assert resp["success"] is False
+    assert "disk full" in resp["error"]
+    # The live switch already happened on the shared dict; only the
+    # persistence failed, and the error says so instead of a silent loss.
+    assert api.config["repeater"]["mode"] == "no_tx"
 
 
 def test_update_duty_cycle_config_branches(cherrypy_ctx):


### PR DESCRIPTION
## Problem

The mode selector at the top of the web UI (Repeater / Monitor / No TX) applies but does not persist. `POST /api/set_mode` mutates the shared config dict — which the engine reads live (`engine.py`, `packet_router.py`), so the switch is immediately effective and *looks* saved — but nothing writes it to disk. The next restart silently reverts the node to whatever mode the config file still holds. Saving currently requires triggering a full config save from another menu.

Where the bug lives, for the record:

- **The UI is blameless.** It calls `/set_mode` expecting it to persist — `SetCommand.ts` even carries the comment *"Use set_mode endpoint which handles both setting and persisting"*. No UI change needed.
- **The repeater has an in-repo precedent for the correct behaviour**: the RF admin path (`glass_handler`, `set_mode` action) persists the very same change through `_apply_config_update`.

## Change

`set_mode` now persists through `config_manager.update_and_save(updates={}, live_update=True, live_update_sections=["repeater"])` — the same blessed path the settings endpoints (`update_duty_cycle_config`, …) already use — and reports `persisted: true`. If the save fails, the live switch stands (matching the old behaviour) but the response is a loud error instead of a silent loss at the next restart.

Note: `set_duty_cycle` next door has the same apply-without-persist pattern; left out deliberately to keep this focused on the mode selector.

## Verification

- Extended `test_set_mode_and_set_duty_cycle_paths`: asserts the `update_and_save` call and the `persisted: true` response.
- New `test_set_mode_save_failure_reports_error`: a failed save returns the error while the live switch stands.
- `tests/test_api_endpoints_core_coverage.py`: 89 passed (1 pre-existing failure in `test_send_advert_paths`, unrelated, present on `dev`).
