### PR TITLE
fix(rooms): advertise settings.node_name from the CLI path too

### DIFF
--- a/repeater/handler_helpers/room_server.py
+++ b/repeater/handler_helpers/room_server.py
@@ -145,8 +145,11 @@ class RoomServer:
                         room_settings = rs.get("settings", {})
                         break
 
-                # Use room-specific name and location
-                node_name = room_settings.get("room_name", room_name)
+                # Use room-specific name and location. Prefer node_name to
+                # match the daemon scheduler and the HTTP endpoint — reading
+                # only room_name here meant one CLI advert renamed the room
+                # on the mesh to the identity-name fallback.
+                node_name = room_settings.get("node_name", room_settings.get("room_name", room_name))
                 latitude = room_settings.get("latitude", 0.0)
                 longitude = room_settings.get("longitude", 0.0)
 

--- a/repeater/main.py
+++ b/repeater/main.py
@@ -1537,7 +1537,7 @@ class RepeaterDaemon:
             settings = (
                 identity_config.get("settings", {}) if isinstance(identity_config, dict) else {}
             )
-            node_name = settings.get("node_name", room_name)
+            node_name = settings.get("node_name", settings.get("room_name", room_name))
             latitude = settings.get("latitude", 0.0)
             longitude = settings.get("longitude", 0.0)
             flags = ADVERT_FLAG_IS_ROOM_SERVER | ADVERT_FLAG_HAS_NAME

--- a/tests/test_handler_helpers_room_server.py
+++ b/tests/test_handler_helpers_room_server.py
@@ -234,6 +234,49 @@ async def test_room_server_send_advert_callback_returns_false_on_inject_failure(
     injector.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_room_server_cli_advert_uses_node_name():
+    """CLI advert must advertise settings.node_name, matching the scheduler.
+
+    The CLI path read only settings.room_name while the daemon scheduler and
+    the HTTP endpoint read settings.node_name -- so a single `advert` from
+    the room CLI renamed the room on the mesh to the identity-name fallback
+    when the two keys differed.
+    """
+    config = {
+        "identities": {
+            "room_servers": [
+                {
+                    "name": "room-alpha",
+                    "settings": {"node_name": "Room Alpha", "latitude": 1.0, "longitude": 2.0},
+                }
+            ]
+        }
+    }
+
+    injector = AsyncMock(return_value=True)
+    rs = RoomServer(
+        room_hash=0x34,
+        room_name="room-alpha",
+        local_identity=_FakeIdentity(b"R" * 32),
+        sqlite_handler=_FakeDB(),
+        packet_injector=injector,
+        acl=_FakeACL(),
+        config_path="/tmp/room.yaml",
+        config=config,
+        config_manager=SimpleNamespace(),
+    )
+
+    packet = SimpleNamespace()
+    with patch(
+        "openhop_core.protocol.PacketBuilder.create_advert", return_value=packet
+    ) as create_advert:
+        ok = await rs.cli.send_advert_callback()
+
+    assert ok is True
+    assert create_advert.call_args.kwargs.get("name") == "Room Alpha"
+
+
 def test_room_server_init_caps_max_posts_to_hard_limit():
     rs = _make_room_server(max_posts=MAX_UNSYNCED_POSTS + 50)
     assert rs.max_posts == MAX_UNSYNCED_POSTS


### PR DESCRIPTION
## Summary

The room advert name is read from two different settings keys depending on the code path:

- daemon scheduler + HTTP endpoint: `settings.node_name` (`main.py`),
- mesh CLI `advert` command: `settings.room_name` (`handler_helpers/room_server.py`).

When only one of the keys is set (the docs and examples lead people to `node_name`), a single `advert` issued over the mesh CLI renames the room on the mesh to the identity-name fallback, and clients track it under that name until the next scheduler advert. We hit this in production on 2026-08-19 and have been running with both keys kept identical as a workaround since.

## Change

Both read sites now resolve `node_name` → `room_name` → identity name, so either key works and the two paths always agree.

## Related

- #407 (rooms lookup confusion — see my comment there for the name-resolution diagnosis)
- #87 (room advert settings)

## Tests

- new: `test_room_server_cli_advert_uses_node_name` — asserts `PacketBuilder.create_advert` is called with the `node_name` value from settings
- `python -m pytest -q tests/test_handler_helpers_room_server.py` — 23 passed
- `ruff check` on the three touched files: identical finding count to `dev` (no new violations)