### PR TITLE
fix: key channel decrypt cache by packet content hash

### DIFF
--- a/repeater/policy_engine.py
+++ b/repeater/policy_engine.py
@@ -57,7 +57,7 @@ class PolicyEngine:
 
         objects = cfg.get("objects")
         self.objects: dict[str, Any] = objects if isinstance(objects, dict) else {}
-        self._channel_decrypt_cache: dict[int, dict[str, Any]] = {}
+        self._channel_decrypt_cache: dict[str, dict[str, Any]] = {}
         self._inline_channel_secrets = self._collect_inline_rule_channel_secrets(self.rules)
 
     @classmethod
@@ -238,7 +238,10 @@ class PolicyEngine:
         return channel_info.get("message_body")
 
     def _get_channel_decrypt_info(self, packet) -> dict[str, Any]:
-        packet_key = id(packet)
+        try:
+            packet_key = packet.calculate_packet_hash().hex().upper()
+        except Exception:
+            packet_key = "id-" + str(id(packet))
         cached = self._channel_decrypt_cache.get(packet_key)
         if isinstance(cached, dict):
             return cached

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -793,3 +793,42 @@ def test_policy_engine_channel_decryptable_uses_channel_hash_group_secret():
 
     assert decision.matched is True
     assert decision.action == "drop"
+
+
+def test_policy_engine_channel_decrypt_cache_not_keyed_by_id():
+    channel_secret = (b"cache-secret" + b"\x00" * 32)[:32].hex()
+    other_secret = (b"cache-other" + b"\x00" * 32)[:32].hex()
+    decryptable = PacketBuilder.create_group_datagram(
+        group_name="ops",
+        local_identity=LocalIdentity(),
+        message="hello from cache test",
+        sender_name="Alice",
+        channels_config=[{"name": "ops", "secret": channel_secret}],
+    )
+    undecryptable = PacketBuilder.create_group_datagram(
+        group_name="ops",
+        local_identity=LocalIdentity(),
+        message="different payload",
+        sender_name="Eve",
+        channels_config=[{"name": "ops", "secret": other_secret}],
+    )
+
+    engine = PolicyEngine(
+        {
+            "enabled": True,
+            "default_action": "allow",
+            "objects": {"channels": {"ops": {"secret": channel_secret}}},
+            "rules": [],
+        }
+    )
+
+    # Python reuses id() once old Packet objects are freed, so an id()-keyed
+    # cache can serve a stale undecryptable entry for an unrelated later
+    # packet. Force both packets to report the same id() to expose that the
+    # cache must actually be keyed by content.
+    with patch("repeater.policy_engine.id", return_value=424242):
+        engine._get_channel_decrypt_info(undecryptable)
+        info = engine._get_channel_decrypt_info(decryptable)
+
+    assert info["decryptable"] is True
+    assert info["sender"] == "Alice"


### PR DESCRIPTION
## Summary

Fixes a bug where policy rules that reference a channel's sender (`channel_sender`) would eventually stop matching packets they should match, until the repeater is restarted.

## Root cause

The policy engine caches channel decrypt results in `_get_channel_decrypt_info()` keyed by `id(packet)`. Python freely reuses `id()` once a `Packet` object is garbage-collected, so a later, unrelated packet can hit a stale cached entry (e.g. an earlier `decryptable=False` result) left behind by a freed packet. When that happens `channel_sender` resolves to `None`, so sender-based rules never match — even for packets that should be matched.

## Fix

Key the decrypt cache by the packet's content hash (`packet.calculate_packet_hash()`) instead of `id()`, so stale entries cannot collide with unrelated packets. For packets that cannot compute a content hash, fall back to a prefixed `id()` key.

## Behavior before/after

- **Before:** policies worked initially, but would silently stop matching over time; restarting the repeater temporarily restored matching.
- **After:** decrypt cache entries are tied to packet content and no longer poison unrelated packets; matching remains reliable.

## Tests

- Added regression test `test_policy_engine_channel_decrypt_cache_not_keyed_by_id` which fails on the old code and passes with the fix.
- Full suite (1530 tests) and pre-commit checks pass.

## Note on the cache

This cache is unbounded and is never evicted (also true of the pre-existing `id()`-keyed version). This change does not introduce or worsen that behavior, but it may be worth a separate follow-up to bound/evict cache entries over time.