### PR TITLE
docs: add CARTO basemap key to config example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -795,6 +795,11 @@ web:
   # Allows web frontends from different origins to access the API
   cors_enabled: false
 
+  # Optional CARTO Basemaps API key for theme-matched light and dark map tiles.
+  # The key is sent to CARTO by each browser; do not treat it as a server-side secret.
+  # When unset, the web interface uses light OpenStreetMap tiles in both themes.
+  carto_api_key: ""
+
   # Custom path to web frontend files (optional)
   # If not specified, uses the default built-in path
   # Example: /opt/custom-web-ui or /home/user/my-frontend


### PR DESCRIPTION
## Summary
- add the optional `web.carto_api_key` setting to the canonical `config.yaml.example`
- document that browsers send this key directly to CARTO, so it must not be treated as a private server-side secret
- document that an unset key uses light OpenStreetMap tiles in both WebUI themes

This formalizes the configuration used by the companion RepeaterUI change: openhop-dev/openHop_RepeaterUI#106.

## Verification
- parsed the complete `config.yaml.example` with PyYAML
- asserted `web.carto_api_key` resolves to an empty string by default
- config-focused backend tests: 30 passed
- `git diff --check` passed

## Test environment note
The local full-suite run was not counted as complete because pytest exited without printing its terminal summary. Upstream CI remains the authoritative full-suite result for this documentation-only change.
